### PR TITLE
The apollo cache should have references not actual objects.

### DIFF
--- a/frontend/src/components/pages/events/createEvent.tsx
+++ b/frontend/src/components/pages/events/createEvent.tsx
@@ -1,5 +1,5 @@
 import { CREATE_EVENT } from "../../../graphql/events/mutations";
-import { useMutation } from "@apollo/client";
+import { gql, useMutation } from "@apollo/client";
 import { useState } from "react";
 
 const CreateEvent = () => {
@@ -16,7 +16,15 @@ const CreateEvent = () => {
             cache.modify({
                 fields: {
                     allEvents: (existingEvents) => {
-                        return [...existingEvents, createEvent.event];
+                        const newEventRef = cache.writeFragment({
+                            data: createEvent.event,
+                            fragment: gql`
+                                fragment NewEvent on Event {
+                                    id
+                                }
+                            `,
+                        });
+                        return [...existingEvents, newEventRef];
                     },
                 },
             });


### PR DESCRIPTION
A small error in the handling of caching newly created objects. The apollo cache should not contain the actually created object, but a reference to the normalized location. This can be done with cache.writeFragment(). We write to the cache and save the reference in the allEvents list.