### PR TITLE
change eslint rule for <a> tags inside <Link>

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -49,6 +49,11 @@
              "depth":25
           }
        ],
+       "jsx-a11y/anchor-is-valid": [ "error", {
+          "components": [ "Link" ],
+          "specialLink": [ "hrefLeft", "hrefRight" ],
+          "aspects": [ "invalidHref", "preferButton" ]
+        }],
        "@typescript-eslint/no-explicit-any":"off"
     },
     "settings":{


### PR DESCRIPTION
Next.js convention is to [include empty &lt;a&gt; tags inside &lt;Link&gt; tags](https://nextjs.org/docs/api-reference/next/link), but this is not accepted by the "anchor-is-valid" rule in eslint. This change makes an exception to this rule [as recommended by the rule's creator](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/402#issuecomment-368305051). This allows us to follow Next.js convention while still using commit hooks.