### PR TITLE
Update prod images to use base images hosted in aws ecr

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/python:3.9
 ENV PYTHONUNBUFFERED 1
 RUN mkdir -p /code
 WORKDIR /code

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM node:12
+FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/node:12
 
 # Create app directory
 RUN mkdir -p /code


### PR DESCRIPTION
Now our base images, `python:3.9` and `node:12`, are hosted in AWS ECR, and the production docker images use the images hosted there instead of the ones hosted in Docker Hub to circumvent the rate-limiting issues we're having.

Closes #38 