### PR TITLE
fix back button using window.close()

### DIFF
--- a/frontend/src/components/pages/cabins/Contract.tsx
+++ b/frontend/src/components/pages/cabins/Contract.tsx
@@ -1,5 +1,5 @@
 import { ArrowIcon } from "@components/ui/ArrowIcon";
-import Router, { useRouter } from "next/router";
+import { useRouter } from "next/router";
 import React, { useEffect } from "react";
 import { useState } from "react";
 import styled from "styled-components";

--- a/frontend/src/components/pages/cabins/Rules.tsx
+++ b/frontend/src/components/pages/cabins/Rules.tsx
@@ -1,5 +1,4 @@
 import { ArrowIcon } from "@components/ui/ArrowIcon";
-import Router from "next/router";
 import React from "react";
 import styled from "styled-components";
 import { HeaderComposition } from "./HeaderCompositon";


### PR DESCRIPTION
Switched Router.back() with window.close() in order for the back buttons to work on both chrome and safari.