### PR TITLE
Critical: prevent MembershipType from leaking user information

### DIFF
--- a/backend/api/graphql/organizations/mutations.py
+++ b/backend/api/graphql/organizations/mutations.py
@@ -101,6 +101,7 @@ class RemoveMembership(graphene.Mutation):
         member_id = graphene.ID()
 
     def mutate(self, info, member_id):
+        raise NotImplementedError("Denne funksjonaliteten er ikke implementert.")
         membership = Membership.objects.get(pk=member_id)
         user: User = membership.user
         membership.delete()

--- a/backend/api/graphql/organizations/resolvers.py
+++ b/backend/api/graphql/organizations/resolvers.py
@@ -37,8 +37,11 @@ def _get_organization_from_slug(slug: str) -> Optional[Organization]:
 
 
 class MembershipResolvers:
-    def resolve_all_memberships(self, info):
-        return Membership.objects.all()
+    def resolve_memberships(self, info, organization_id):
+        organization = Organization.objects.get(pk=organization_id)
+        if organization.users.filter(user=info.context.user).exists():
+            return Membership.objects.filter(organization=organization)
+        raise PermissionError(f"Du må være medlem av {organization} for å gjøre dette kallet.")
 
-    def resolve_all_rolves(self, info):
+    def resolve_all_roles(self, info):
         return Role.objects.all()

--- a/backend/api/graphql/organizations/schema.py
+++ b/backend/api/graphql/organizations/schema.py
@@ -19,8 +19,6 @@ class OrganizationMutations(graphene.ObjectType):
 
     create_role = CreateRole.Field()
     assign_membership = AssignMembership.Field()
-    remove_membership = RemoveMembership.Field()
-
 
 class OrganizationQueries(
     graphene.ObjectType, OrganizationResolvers, MembershipResolvers
@@ -33,5 +31,5 @@ class OrganizationQueries(
     )
     event_filtered_organizations = graphene.List(OrganizationType)
 
-    all_memberships = graphene.List(MembershipType)
+    memberships = graphene.List(MembershipType, organization_id=graphene.ID())
     all_roles = graphene.List(RoleType)

--- a/backend/api/graphql/organizations/types.py
+++ b/backend/api/graphql/organizations/types.py
@@ -47,9 +47,26 @@ class OrganizationType(DjangoObjectType):
 class MembershipType(DjangoObjectType):
     class Meta:
         model = Membership
+        fields = ["id", "role", "organization", "user"]
+
+    class PermissionDecorators:
+        @staticmethod
+        def is_in_organization(resolver):
+            def wrapper(membership: Membership, info):
+                if membership.organization.users.filter(pk=info.context.user.id).exists():
+                    return resolver(membership, info)
+                else:
+                    raise PermissionError(f"Du må være medlem av organisasjonen {membership.organization.name} for å gjøre dette kallet")
+
+            return wrapper
+
+    @PermissionDecorators.is_in_organization
+    def resolve_user(membership, info):
+        return membership.user
 
 
 class RoleType(DjangoObjectType):
     class Meta:
         model = Role
+        fields = ["id", "name"]
         


### PR DESCRIPTION
It is currently possible to access user data by running the query 
```gql
query {
    AllMemberships {
        user {
            id
            username
        }
    }
}
```

This PR addresses the issue with some quick and dirty band-aid solutions to prevent unauthorized calls.