### PR TITLE
tweak typography and make availableSlots available if permitted

### DIFF
--- a/frontend/src/components/pages/events/AllEvents/EventListItem.tsx
+++ b/frontend/src/components/pages/events/AllEvents/EventListItem.tsx
@@ -48,8 +48,8 @@ const EventListItem: React.FC<Props> = ({ event, user, classes }) => {
         style={{ borderColor: event.organization?.color ?? theme.palette.primary.main }}
       >
         <Box>
-          <Typography variant="h6">{event.title}</Typography>
-          <Typography variant="body1">{formatDate(event.startTime)}</Typography>
+          <Typography variant="h5">{event.title}</Typography>
+          <Typography variant="body2">{formatDate(event.startTime)}</Typography>
 
           {event.shortDescription ?? "Trykk for å lese mer"}
         </Box>

--- a/frontend/src/graphql/events/queries.ts
+++ b/frontend/src/graphql/events/queries.ts
@@ -110,6 +110,7 @@ export const GET_EVENT = gql`
         lastName
         dateJoined
       }
+      availableSlots
       price
       shortDescription
       signupOpenDate


### PR DESCRIPTION
- Make the event list view nicer by tweaking the text
- Ensure that all fields are pre-populated when editing an event by adding `availableSlots` to `GET_EVENT`, but only return the number of slots if the user has permission