### PR TITLE
remove border radius and add box shadow

### DIFF
--- a/frontend/src/components/pages/cabins/ImageSlider/ImageSlider.tsx
+++ b/frontend/src/components/pages/cabins/ImageSlider/ImageSlider.tsx
@@ -16,10 +16,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     overflow: "hidden",
     width: "100%",
   },
-  imageContainer: {
-    boxShadow: "1px 2px 8px 0px rgba(0,0,0,0.75)",
-    marginBottom: "10px",
-  },
   mobileStepper: {
     backgroundColor: theme.palette.background.paper,
   },
@@ -71,7 +67,7 @@ const ImageSlider = ({ imageData, displayLabelText }: imageSliderProps): JSX.Ele
       ) : (
         ""
       )}
-      <Box className={classes.imageContainer}>
+      <Box>
         <SwipeableViews
           axis={theme.direction === "rtl" ? "x-reverse" : "x"}
           index={activeStep}


### PR DESCRIPTION
Fixes #101 
Removed border radius and added box-shadow to images in imageslider.
This is what it looks like after the proposed changes: 
<img width="1370" alt="Screenshot 2021-03-19 at 14 56 42" src="https://user-images.githubusercontent.com/19520716/111794180-3fc96f00-88c6-11eb-951f-701b028eac52.png">

Looking forward to hearing your thoughts @Skraagen & @ankile!

