### PR TITLE
move straight from accept contract to payment

### DIFF
--- a/frontend/src/components/pages/cabins/Popup/ContractDialog.tsx
+++ b/frontend/src/components/pages/cabins/Popup/ContractDialog.tsx
@@ -24,9 +24,19 @@ interface ContractDialogProps {
   datePick: DatePick;
   chosenCabins: Cabin[];
   contactInfo: ContactInfo;
+  activeStep: number;
+  setActiveStep: Dispatch<SetStateAction<number>>;
 }
 
-const ContractDialog = ({ modalData, setModalData, datePick, chosenCabins, contactInfo }: ContractDialogProps) => {
+const ContractDialog = ({
+  modalData,
+  setModalData,
+  datePick,
+  chosenCabins,
+  contactInfo,
+  activeStep,
+  setActiveStep,
+}: ContractDialogProps) => {
   const classes = useStyles();
 
   const handleClose = () => {
@@ -35,6 +45,7 @@ const ContractDialog = ({ modalData, setModalData, datePick, chosenCabins, conta
 
   const handleAccept = () => {
     setModalData({ displayPopUp: false, contractViewed: true });
+    setActiveStep(activeStep + 1);
   };
 
   return (

--- a/frontend/src/pages/cabins/book/index.tsx
+++ b/frontend/src/pages/cabins/book/index.tsx
@@ -123,6 +123,8 @@ const CabinBookingPage: NextPage = () => {
         chosenCabins={chosenCabins}
         datePick={datePick}
         contactInfo={contactInfo}
+        activeStep={activeStep}
+        setActiveStep={setActiveStep}
       />
       <Box m={10}>
         <Grid container direction="column" justify="center" spacing={1}>


### PR DESCRIPTION
A user is now sent directly to the next step (payment) when accepting the contract, as opposed to first click "accept contract" and then click next step.