### PR TITLE
Fix: get_anonymous_user_instance import string

### DIFF
--- a/backend/api/settings.py
+++ b/backend/api/settings.py
@@ -131,7 +131,6 @@ AUTHENTICATION_BACKENDS = [
 # https://django-guardian.readthedocs.io/en/stable/userguide/custom-user-model.html#anonymous-user-creation
 GUARDIAN_GET_INIT_ANONYMOUS_USER = "apps.users.models.get_anonymous_user_instance"
 
-
 DATAPORTEN_ID = env("DATAPORTEN_ID")
 DATAPORTEN_SECRET = env("DATAPORTEN_SECRET")
 DATAPORTEN_REDIRECT_URI = env("DATAPORTEN_REDIRECT_URI")

--- a/backend/apps/users/models.py
+++ b/backend/apps/users/models.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AbstractUser
 from django.db import models
+from guardian.conf import settings as guardian_settings
 from phonenumber_field.modelfields import PhoneNumberField
 import datetime
 
@@ -37,4 +38,6 @@ class User(AbstractUser):
 
 
 def get_anonymous_user_instance(User):
-    return User(feide_userid="AnonymousUser")
+    anonymous_username = guardian_settings.ANONYMOUS_USER_NAME
+    attributes = {"feide_userid": anonymous_username, User.USERNAME_FIELD: anonymous_username}
+    return User(**attributes)


### PR DESCRIPTION
#124 

~~Unsure if further actions are required fix the initial failure during the creation of the AnonymousUser instance.~~
**Edit:** As the create_anonymous_user function is listening to ```signals.post_migrate```, the user should be recreated when `migrate` is run.
**Edit2:** Running some additional checks to verify that it is working as expected.
**Edit3:** Should work as expected now.
**Edit4:** see #126 