### PR TITLE
🐛  fix: remove unused chips from ListingItem

### DIFF
--- a/frontend/src/components/pages/listings/ListingItem.tsx
+++ b/frontend/src/components/pages/listings/ListingItem.tsx
@@ -5,8 +5,6 @@ import {
   CardActionArea,
   CardContent,
   CardMedia,
-  Chip,
-  Grid,
   makeStyles,
   Typography,
 } from "@material-ui/core";
@@ -125,19 +123,6 @@ const ListingItem: React.FC<{
                   {listing.description}
                 </Typography>
               </Box>
-              <Grid container direction="row" justify="center" alignItems="center" spacing={2}>
-                {["intervju", "søknad", "case"].map((chip) => (
-                  <Grid item key={chip}>
-                    <Chip
-                      label={chip}
-                      size="small"
-                      style={{
-                        fontSize: 12,
-                      }}
-                    />
-                  </Grid>
-                ))}
-              </Grid>
             </Box>
           </CardContent>
         </CardActionArea>


### PR DESCRIPTION
Remove the temporary chips from ListingItem so that it people don't think that LP in HS requires interviews, case, and an application.