### PR TITLE
Return null to frontend if anonymous user

### DIFF
--- a/backend/api/graphql/users/resolvers.py
+++ b/backend/api/graphql/users/resolvers.py
@@ -3,12 +3,15 @@ from django.contrib.auth import get_user_model
 
 
 class UserResolvers:
-    def resolve_user(parent, info):
-        if isinstance(info.context.user, get_user_model()):
+    def resolve_user(self, info):
+        if (
+            isinstance(info.context.user, get_user_model())
+            and not info.context.user.is_anonymous
+        ):
             return info.context.user
         else:
             return None
 
     @staff_member_required
-    def resolve_all_users(parent, info):
+    def resolve_all_users(self, info):
         return get_user_model().objects.all()


### PR DESCRIPTION
Fix login check after logged in users became the `AnonymousUser` user by return `None` if user is not authenticated (i.e. username is `settings.ANONYMOUS_USER_NAME`.