### PR TITLE
Fix: Update organization query to reflect new event structure

### DIFF
--- a/frontend/src/graphql/orgs/queries.ts
+++ b/frontend/src/graphql/orgs/queries.ts
@@ -14,13 +14,17 @@ export const GET_ORGANIZATION = gql`
         isFull
         usersAttending {
           id
-          username
-          firstName
+          user {
+            username
+            firstName
+          }
         }
         usersOnWaitingList {
           id
-          username
-          firstName
+          user {
+            username
+            firstName
+          }
         }
       }
       listings {


### PR DESCRIPTION
PR #163 broke the organization admin page, as it did not update the GET_ORGANIZATION GraphQL query frontend to reflect the new structure of the usersAttending and usersOnWaitingList fields on events. This fixes that.