### PR TITLE
fix: reference user_id instead of user

### DIFF
--- a/backend/apps/organizations/mutations.py
+++ b/backend/apps/organizations/mutations.py
@@ -11,6 +11,7 @@ from . import permissions as perms
 from .models import Membership, Organization
 from .types import MembershipType, OrganizationType
 
+
 def get_organization_from_data(*_, membership_data, **kwargs) -> Organization:
     return Organization.objects.get(pk=membership_data["organization_id"])
 
@@ -98,7 +99,7 @@ class AssignMembership(graphene.Mutation):
     def mutate(self, _, membership_data):
         membership = Membership(
             organization_id=membership_data["organization_id"],
-            user=membership_data["user_id"],
+            user_id=membership_data["user_id"],
             group_id=membership_data.get("group_id", None),
         )
         membership.save()


### PR DESCRIPTION
#### What problem/feature does this pull request fix/add?

Assign membership mutation references a user object, but should reference user_id.

### Checklist

- [ ] All tests have passed
- [ ] I have created new tests for this feature (may not be applicable to all pull requests)
- [ ] I am pleased with the readability of the code (if not, state where you need input)
