### PR TITLE
fix: add url to listing creation and editing

### DIFF
--- a/frontend/src/pages/orgs/[orgId]/listings/[listingId]/edit.tsx
+++ b/frontend/src/pages/orgs/[orgId]/listings/[listingId]/edit.tsx
@@ -73,7 +73,6 @@ const EditListingPage: NextPage = () => {
                         application: listing.application || undefined,
                         interview: listing.interview || undefined,
                         case: listing.case || undefined,
-                        url: listing.url || undefined,
                       },
                     },
                   });


### PR DESCRIPTION
#### What problem/feature does this pull request fix/add?

Creating a listing with an application URL did not in fact add the URL to the listing.

#### (if not a new problem) How was this problem solved earlier?

#### How did I fix this problem?

URL is now added on listing creation.

### Checklist

- [ ] All tests have passed
- [ ] I have created new tests for this feature (may not be applicable to all pull requests)
- [x] I am pleased with the readability of the code (if not, state where you need input)
