### PR TITLE
fix: add migration to add organization members to HR permission groups

### DIFF
--- a/backend/apps/organizations/migrations/0031_membership_groups.py
+++ b/backend/apps/organizations/migrations/0031_membership_groups.py
@@ -2,53 +2,49 @@ from django.db import migrations, models
 from apps.permissions.constants import ORGANIZATION
 
 def add_org_members_to_permission_groups(apps, schema_editor):
-  MembershipModel = apps.get_model('organizations', 'Membership')
-  GroupModel = apps.get_model('auth', 'Group')
-  UserModel = apps.get_model('users', 'User')
+    MembershipModel = apps.get_model('organizations', 'Membership')
+    GroupModel = apps.get_model('auth', 'Group')
+    UserModel = apps.get_model('users', 'User')
 
-  organization_member_group = GroupModel.objects.get(name=ORGANIZATION)
+    organization_member_group = GroupModel.objects.get(name=ORGANIZATION)
 
-  for membership in MembershipModel.objects.all():
-    user = UserModel.objects.get(id=membership.user.id)
+    for membership in MembershipModel.objects.all():
+        user = UserModel.objects.get(id=membership.user.id)
 
-    if organization_member_group not in user.groups.all():
-      user.groups.add(organization_member_group)
-      print(f"User {membership.user.username} added to Organization member group")
+        if organization_member_group not in user.groups.all():
+            user.groups.add(organization_member_group)
 
-    organization_hr_group = membership.organization.hr_group.group
+        organization_hr_group = membership.organization.hr_group.group
 
-    if membership.group.group == organization_hr_group and organization_hr_group not in user.groups.all():
-      user.groups.add(organization_hr_group)
-      print(f"User {membership.user.username} added to {membership.organization.name}'s HR group")
+        if membership.group.group == organization_hr_group and organization_hr_group not in user.groups.all():
+            user.groups.add(organization_hr_group)
     
 
 def remove_org_members_from_permission_groups(apps, schema_editor):
-  MembershipModel = apps.get_model('organizations', 'Membership')
-  GroupModel = apps.get_model('auth', 'Group')
-  UserModel = apps.get_model('users', 'User')
+    MembershipModel = apps.get_model('organizations', 'Membership')
+    GroupModel = apps.get_model('auth', 'Group')
+    UserModel = apps.get_model('users', 'User')
 
-  organization_member_group = GroupModel.objects.get(name=ORGANIZATION)
+    organization_member_group = GroupModel.objects.get(name=ORGANIZATION)
 
-  for membership in MembershipModel.objects.all():
-    user = UserModel.objects.get(id=membership.user.id)
+    for membership in MembershipModel.objects.all():
+        user = UserModel.objects.get(id=membership.user.id)
 
-    if organization_member_group in user.groups.all():
-      user.groups.remove(organization_member_group)
-      print(f"User {membership.user.username} removed from Organization member group")
+        if organization_member_group in user.groups.all():
+            user.groups.remove(organization_member_group)
 
-    organization_hr_group = membership.organization.hr_group.group
+        organization_hr_group = membership.organization.hr_group.group
 
-    if membership.group.group == organization_hr_group and organization_hr_group in user.groups.all():
-      user.groups.remove(organization_hr_group)
-      print(f"User {membership.user.username} removed from {membership.organization.name}'s HR group")
+        if membership.group.group == organization_hr_group and organization_hr_group in user.groups.all():
+            user.groups.remove(organization_hr_group)
 
 class Migration(migrations.Migration):
 
-  dependencies = [
-    ('organizations', '0030_auto_20210426_2129'),
-    ('users', '0007_auto_20210312_1746')
-  ]
+    dependencies = [
+        ('organizations', '0030_auto_20210426_2129'),
+        ('users', '0007_auto_20210312_1746')
+    ]
 
-  operations = [
-    migrations.RunPython(add_org_members_to_permission_groups, remove_org_members_from_permission_groups)
-  ]
+    operations = [
+        migrations.RunPython(add_org_members_to_permission_groups, remove_org_members_from_permission_groups)
+    ]


### PR DESCRIPTION
#### What problem/feature does this pull request fix/add?

On the website as is, users who are assigned a membership to an organization's HR group are not in fact placed in the HR group, and in some cases, neither in the generic Organization member group.

#### How did I fix this problem?

By making a migration that runs through all memberships, and checks if the relevant user is added to the HR group corresponding to that membership, and the Organization member group. If they are not added yet, the migration adds them to the group.

### Checklist

- [ ] All tests have passed
- [ ] I have created new tests for this feature (may not be applicable to all pull requests)
- [x] I am pleased with the readability of the code (if not, state where you need input)
