### PR TITLE
Make README images dark mode responsive

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 [![Open Source](https://badges.frapsoft.com/os/v1/open-source.svg?v=103)](https://opensource.org/)
 ![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)
 
-Website for the students at Industrial Economics and Technology Management at NTNU. Built with Django, React/Next.js, and GraphQL API. Built and maintained by Rubberdøk NTNU.
+Website for the students at Industrial Economics and Technology Management at NTNU Trondheim. Built with Django, React/Next.js, and GraphQL API. Built and maintained by Rubberdøk NTNU.
 
 <p align="center">
   <a href="https://www.indokntnu.no/">
@@ -118,6 +118,10 @@ In short, the process is as follows:
   &nbsp;
   <a href="https://nextjs.org">
     <img alt="NextJS" src="https://github.com/hovedstyret/indok-web/blob/docs/assets/nextjs_logo.svg" height="50">
+  </a>
+  &nbsp;
+  <a href="https://www.typescriptlang.org/">
+    <img alt="TypeScript" src="https://upload.wikimedia.org/wikipedia/commons/4/4c/Typescript_logo_2020.svg" height="50">
   </a>
   &nbsp;
   <a href="https://www.python.org">


### PR DESCRIPTION
#### What problem/feature does this pull request fix/add?

Previously, the logos used in our readme did not mesh well with GitHub's new dark mode.

#### How did I fix this problem?

Dark mode responsive SVGs (using style attributes and media queries) are already added to docs/assets. This PR adds the paths to these new files to the readme, and also adds the TypeScript logo.

### Checklist

- [ ] All tests have passed
- [ ] I have created new tests for this feature (may not be applicable to all pull requests)
- [x] I am pleased with the readability of the code (if not, state where you need input)
