### PR TITLE
fix: remove trailing slashes from frontend volume config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     volumes:
-      - ./frontend/:/app/
+      - ./frontend:/app
       - /app/node_modules
       - /app/.next
     ports:


### PR DESCRIPTION
## Proposed Changes

- Remove trailing slashes from the config of frontend volumes in docker-compose.yml

The trailing slashes [breaks Docker on Windows 10](https://stackoverflow.com/questions/68273745/how-to-make-a-mount-shared-in-docker).

## Types of Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
