### PR TITLE
🐞 fix(about): restore board info panel

### DIFF
--- a/frontend/content/organizations/bandok.md
+++ b/frontend/content/organizations/bandok.md
@@ -3,15 +3,15 @@ title: Bandøk
 description: Indøks helt egne band
 logo: /img/bandoklogo.png
 image: /img/bandoklogo.png
-styre:
+board:
   ceo:
-    navn: Johannes Log Indbjo
-    mail: tlf.
-    tittel: Administrerende ansvarlig
+    name: Johannes Log Indbjo
+    mail:
+    title: Administrerende ansvarlig
   cto:
-    navn: Sigurd Elias Halse
-    mail: tlf.
-    tittel: Økonomiansvarlig/utstyrsansvarlig
+    name: Sigurd Elias Halse
+    mail:
+    title: Økonomiansvarlig/utstyrsansvarlig
 tag: kultur
 ---
 

--- a/frontend/content/organizations/bulldok.md
+++ b/frontend/content/organizations/bulldok.md
@@ -3,11 +3,11 @@ title: Bulldøk
 description: Indøks buldre- og klatregruppe
 logo: /img/bulldok.jpeg
 image: /img/bulldok.jpeg
-styre:
+board:
   ceo:
-    navn: Bendik Edvardsen
+    name: Bendik Edvardsen
     mail:
-    tittel: Leder
+    title: Leder
 tag: idrett
 ---
 

--- a/frontend/content/organizations/business.md
+++ b/frontend/content/organizations/business.md
@@ -3,23 +3,23 @@ title: Indøk Business Club
 description: Indøks helt egne case-klubb
 logo: /img/IBClogo.png
 image: /img/IBCmote.jpeg
-styre:
+board:
   ceo:
-    navn: Håkon Andreas Hyttedalen
-    telefon: 974 09 177
-    tittel: Leder
+    name: Håkon Andreas Hyttedalen
+    phoneNumber: 974 09 177
+    title: Leder
   cto:
-    navn: Anders Rønning
-    telefon: 913 51 892
-    tittel: Nestleder
-  styre:
-    navn: Tobias Spinnangr Sindre
-    telefon: 954 57 507
-    tittel: Styremedlem
+    name: Anders Rønning
+    phoneNumber: 913 51 892
+    title: Nestleder
+  board:
+    name: Tobias Spinnangr Sindre
+    phoneNumber: 954 57 507
+    title: Styremedlem
   markedsføring:
-    navn: Camilla Elise Espelund
-    telefon: 942 97 714
-    tittel: Styremedlem/Markedsføring
+    name: Camilla Elise Espelund
+    phoneNumber: 942 97 714
+    title: Styremedlem/Markedsføring
 tag: annet
 ---
 

--- a/frontend/content/organizations/eiv.md
+++ b/frontend/content/organizations/eiv.md
@@ -3,23 +3,23 @@ title: Eksperter i Vin
 description: Hever indøks vinkompetanse
 logo: /img/eivlogo.jpg
 image: /img/eivbilde.jpg
-styre:
+board:
   ceo:
-    navn: Phillip Kolkmeier
+    name: Phillip Kolkmeier
     mail: tlf.
-    tittel: Sommelier
+    title: Sommelier
   cto:
-    navn: Erlend Heir
+    name: Erlend Heir
     mail: tlf.
-    tittel: Sommelier
+    title: Sommelier
   cfo:
-    navn: Haakon Døssland
+    name: Haakon Døssland
     mail: tlf.
-    tittel: Sommelier
+    title: Sommelier
   cmo:
-    navn: Ane Sandvik Rognskaug
+    name: Ane Sandvik Rognskaug
     mail: tlf.
-    tittel: Sommelier
+    title: Sommelier
 
 tag: kultur
 ---

--- a/frontend/content/organizations/eiv.md
+++ b/frontend/content/organizations/eiv.md
@@ -6,19 +6,15 @@ image: /img/eivbilde.jpg
 board:
   ceo:
     name: Phillip Kolkmeier
-    mail: tlf.
     title: Sommelier
   cto:
     name: Erlend Heir
-    mail: tlf.
     title: Sommelier
   cfo:
     name: Haakon Døssland
-    mail: tlf.
     title: Sommelier
   cmo:
     name: Ane Sandvik Rognskaug
-    mail: tlf.
     title: Sommelier
 
 tag: kultur

--- a/frontend/content/organizations/hyttestyret.md
+++ b/frontend/content/organizations/hyttestyret.md
@@ -3,27 +3,27 @@ title: Hyttestyret
 description: Gjengen som passer på hyttene våre
 logo: /img/hylogo.jpg
 image: /img/hy1.jpg
-styre:
+board:
   leder:
-    navn: Phillip Kolkmeier
-    telefon: 906 71 650
-    tittel: Leder
+    name: Phillip Kolkmeier
+    phoneNumber: 906 71 650
+    title: Leder
   log:
-    navn: Sjur Filip Vik Haakestad
-    telefon: 919 97 470
-    tittel: Logistikkansvarlig
+    name: Sjur Filip Vik Haakestad
+    phoneNumber: 919 97 470
+    title: Logistikkansvarlig
   book:
-    navn: Ellie Berglund
-    telefon: 942 58 380
-    tittel: Bookingansvarlig
+    name: Ellie Berglund
+    phoneNumber: 942 58 380
+    title: Bookingansvarlig
   drift:
-    navn: Marte Vingsnes
-    telefon: 482 60 767
-    tittel: Driftsansvarlig
+    name: Marte Vingsnes
+    phoneNumber: 482 60 767
+    title: Driftsansvarlig
   øko:
-    navn: Haakon Døssland
-    telefon: 976 30 582
-    tittel: Økonomiansvarlig
+    name: Haakon Døssland
+    phoneNumber: 976 30 582
+    title: Økonomiansvarlig
 tag: annet
 ---
 

--- a/frontend/content/organizations/indokrevyen.md
+++ b/frontend/content/organizations/indokrevyen.md
@@ -3,7 +3,7 @@ title: Indøkrevyen
 description: Norges beste studentrevy?
 logo: /img/indokrevylogo.jpg
 image: /img/indokrevyenbilde.jpg
-styre:
+board:
 tag: kultur
 ---
 

--- a/frontend/content/organizations/indoktennis.md
+++ b/frontend/content/organizations/indoktennis.md
@@ -3,11 +3,11 @@ title: Indøk Tennisklubb
 description: Obligatorisk å klaske tennisball på Indøk
 image: /img/indoktennis.jpg
 logo: /img/indoktennis.jpg
-styre:
+board:
   ceo:
-    navn: Richard Rogstad
+    name: Richard Rogstad
     mail: tlf. 924 34 994
-    tittel: Leder
+    title: Leder
 tag: idrett
 ---
 

--- a/frontend/content/organizations/indoktennis.md
+++ b/frontend/content/organizations/indoktennis.md
@@ -6,7 +6,7 @@ logo: /img/indoktennis.jpg
 board:
   ceo:
     name: Richard Rogstad
-    mail: tlf. 924 34 994
+    phoneNumber: 924 34 994
     title: Leder
 tag: idrett
 ---

--- a/frontend/content/organizations/indol.md
+++ b/frontend/content/organizations/indol.md
@@ -6,19 +6,19 @@ image: /img/indolbilde.jpg
 board:
   ceo:
     name: Hans Magnus Utne
-    mail: tlf. 975 18 033
+    phoneNumber: 975 18 033
     title: Leder
   cto:
     name: Phillip Kolkmeier
-    mail: tlf. 906 71 650
+    phoneNumber: 906 71 650
     title: Nestleder
   brygg:
     name: Olav Førland
-    mail: tlf. 902 25 335
+    phoneNumber: 902 25 335
     title: Bryggeansvarlig
   pr:
     name: Marte Vingsnes
-    mail: tlf. 482 60 767
+    phoneNumber: 482 60 767
     title: PR-ansvarlig
 tag: kultur
 ---

--- a/frontend/content/organizations/indol.md
+++ b/frontend/content/organizations/indol.md
@@ -3,23 +3,23 @@ title: Indøks Ølbryggerlaug
 description: Et helt lovlig bryggeri
 logo: /img/indollogo.png
 image: /img/indolbilde.jpg
-styre:
+board:
   ceo:
-    navn: Hans Magnus Utne
+    name: Hans Magnus Utne
     mail: tlf. 975 18 033
-    tittel: Leder
+    title: Leder
   cto:
-    navn: Phillip Kolkmeier
+    name: Phillip Kolkmeier
     mail: tlf. 906 71 650
-    tittel: Nestleder
+    title: Nestleder
   brygg:
-    navn: Olav Førland
+    name: Olav Førland
     mail: tlf. 902 25 335
-    tittel: Bryggeansvarlig
+    title: Bryggeansvarlig
   pr:
-    navn: Marte Vingsnes
+    name: Marte Vingsnes
     mail: tlf. 482 60 767
-    tittel: PR-ansvarlig
+    title: PR-ansvarlig
 tag: kultur
 ---
 

--- a/frontend/content/organizations/ivi.md
+++ b/frontend/content/organizations/ivi.md
@@ -3,15 +3,15 @@ title: Indøks Veldedige Initiativ
 description: Gjør verden til et bedre sted
 image: /img/ivibilde.jpg
 logo: /img/ivilogo.png
-styre:
+board:
   ceo:
-    navn: Torjus Hagen
+    name: Torjus Hagen
     mail: andreomd@stud.ntnu.no
-    tittel: Leder
+    title: Leder
   cto:
-    navn: Andrea Omdahl
+    name: Andrea Omdahl
     mail: andreomd@stud.ntnu.no
-    tittel: Leder
+    title: Leder
 
 tag: kultur
 ---

--- a/frontend/content/organizations/janusfk.md
+++ b/frontend/content/organizations/janusfk.md
@@ -3,15 +3,15 @@ title: Janus FK
 description: Indøks fotballag for herrer
 logo: /img/FK_logo.jpg
 image: /img/fkbilde.jpg
-styre:
+board:
   ceo:
-    navn: Henrik Planke Berg
+    name: Henrik Planke Berg
     mail: tlf. 975 18 033
-    tittel: Leder
+    title: Leder
   cto:
-    navn: Christian Bakke Vennerød
+    name: Christian Bakke Vennerød
     mail: tlf. 906 71 650
-    tittel: Trener
+    title: Trener
 tag: idrett
 ---
 

--- a/frontend/content/organizations/janusfk.md
+++ b/frontend/content/organizations/janusfk.md
@@ -6,11 +6,11 @@ image: /img/fkbilde.jpg
 board:
   ceo:
     name: Henrik Planke Berg
-    mail: tlf. 975 18 033
+    phoneNumber: 975 18 033
     title: Leder
   cto:
     name: Christian Bakke Vennerød
-    mail: tlf. 906 71 650
+    phoneNumber: 906 71 650
     title: Trener
 tag: idrett
 ---

--- a/frontend/content/organizations/janusfkfk.md
+++ b/frontend/content/organizations/janusfkfk.md
@@ -6,11 +6,9 @@ image: /img/fkfkbilde.png
 board:
   ceo:
     name: Sunniva Økland
-    mail: tlf.
     title: Chief Executive Officer
   cto:
     name: Elin Ulsaker
-    mail: tlf.
     title: Chief Financial Officer
 tag: idrett
 ---

--- a/frontend/content/organizations/janusfkfk.md
+++ b/frontend/content/organizations/janusfkfk.md
@@ -3,15 +3,15 @@ title: Janus FKFK
 description: Indøks fotballag for kvinner
 logo: /img/fkfklogo.png
 image: /img/fkfkbilde.png
-styre:
+board:
   ceo:
-    navn: Sunniva Økland
+    name: Sunniva Økland
     mail: tlf.
-    tittel: Chief Executive Officer
+    title: Chief Executive Officer
   cto:
-    navn: Elin Ulsaker
+    name: Elin Ulsaker
     mail: tlf.
-    tittel: Chief Financial Officer
+    title: Chief Financial Officer
 tag: idrett
 ---
 

--- a/frontend/content/organizations/janushk.md
+++ b/frontend/content/organizations/janushk.md
@@ -3,15 +3,15 @@ title: Janus HK
 description: Indøks håndballag
 logo: /img/FK_logo.jpg
 image: /img/janushklogo.jpg
-styre:
+board:
   ceo:
-    navn: Maren Larsen
-    telefon: 916 49 220
-    tittel: Leder
+    name: Maren Larsen
+    phoneNumber: 916 49 220
+    title: Leder
   cto:
-    navn: Emilie Bakke-Jakobsen
-    telefon: 414 99 925
-    tittel: Økonomiansvarlig
+    name: Emilie Bakke-Jakobsen
+    phoneNumber: 414 99 925
+    title: Økonomiansvarlig
 tag: idrett
 ---
 

--- a/frontend/content/organizations/janustrikk.md
+++ b/frontend/content/organizations/janustrikk.md
@@ -6,11 +6,9 @@ image: /img/janusstrikk.jpg
 board:
   ceo:
     name: Maren Barth
-    mail:
     title: Leder
   cto:
     name: Amanda Krutnes
-    mail:
     title: Leder
 tag: annet
 ---

--- a/frontend/content/organizations/janustrikk.md
+++ b/frontend/content/organizations/janustrikk.md
@@ -3,15 +3,15 @@ title: Janustrikk
 description: Indøks strikkelag for alle kjønn
 logo: /img/janusstrikk.jpg
 image: /img/janusstrikk.jpg
-styre:
+board:
   ceo:
-    navn: Maren Barth
+    name: Maren Barth
     mail:
-    tittel: Leder
+    title: Leder
   cto:
-    navn: Amanda Krutnes
+    name: Amanda Krutnes
     mail:
-    tittel: Leder
+    title: Leder
 tag: annet
 ---
 

--- a/frontend/content/organizations/mkm.md
+++ b/frontend/content/organizations/mkm.md
@@ -3,11 +3,11 @@ title: Mannskoret Klingende Mynt
 description: Musical management consulting
 logo: /img/mkmlogo.png
 image: /img/mkm.jpg
-styre:
+board:
   ceo:
-    navn: Kristoffer Winther
+    name: Kristoffer Winther
     mail: ceo@klingendemynt.no
-    tittel: CEO
+    title: CEO
 
 tag: kultur
 ---

--- a/frontend/content/organizations/pandemics.md
+++ b/frontend/content/organizations/pandemics.md
@@ -6,7 +6,7 @@ image: /img/pandemics.jpg
 board:
   ceo:
     name: Simen Vadseth
-    mail: tlf. 41634151
+    phoneNumber: 41634151
     title: Leder
 tag: idrett
 ---

--- a/frontend/content/organizations/pandemics.md
+++ b/frontend/content/organizations/pandemics.md
@@ -3,11 +3,11 @@ title: Pandemics
 description: Indøks amerikanske fotballag
 logo: /img/pandemicslogo.jpg
 image: /img/pandemics.jpg
-styre:
+board:
   ceo:
-    navn: Simen Vadseth
+    name: Simen Vadseth
     mail: tlf. 41634151
-    tittel: Leder
+    title: Leder
 tag: idrett
 ---
 

--- a/frontend/content/organizations/rubberdok.md
+++ b/frontend/content/organizations/rubberdok.md
@@ -4,7 +4,7 @@ description: Webkomitéen til Hovedstyret på Indøk
 logo: /img/rubberdok_logo_black.svg
 image: /img/rubberdoklogo1.png
 alt: Logoen til rubberdøk
-styre:
+board:
   ceo:
     navn: Lars Waage
     tittel: Prosjektleder

--- a/frontend/content/organizations/schack.md
+++ b/frontend/content/organizations/schack.md
@@ -3,11 +3,11 @@ title: Janus Schack Klub
 description: Sjakk matt
 logo: /img/schacklogo.jpg
 image: /img/hero.jpg
-styre:
+board:
   ceo:
-    navn:
+    name:
     mail:
-    tittel:
+    title:
 tag: idrett
 ---
 

--- a/frontend/content/organizations/ski-og-lop.md
+++ b/frontend/content/organizations/ski-og-lop.md
@@ -6,15 +6,12 @@ image: /img/jslk.jpg
 board:
   ceo:
     name: Kristoffer Jonsson
-    mail:
     title: Leder
   cto:
     name: Jostein Hjortland Tysse
-    mail:
     title: Nestleder
   cfo:
     name: Asbjørn Nisi
-    mail:
     title: Økonomiansvarlig
 
 tag: idrett

--- a/frontend/content/organizations/ski-og-lop.md
+++ b/frontend/content/organizations/ski-og-lop.md
@@ -3,19 +3,19 @@ title: Janus Ski- og Løpeklubb
 description: Den raskeste gjengen
 logo: /img/jslklogo.png
 image: /img/jslk.jpg
-styre:
+board:
   ceo:
-    navn: Kristoffer Jonsson
+    name: Kristoffer Jonsson
     mail:
-    tittel: Leder
+    title: Leder
   cto:
-    navn: Jostein Hjortland Tysse
+    name: Jostein Hjortland Tysse
     mail:
-    tittel: Nestleder
+    title: Nestleder
   cfo:
-    navn: Asbjørn Nisi
+    name: Asbjørn Nisi
     mail:
-    tittel: Økonomiansvarlig
+    title: Økonomiansvarlig
 
 tag: idrett
 ---

--- a/frontend/content/organizations/tindok.md
+++ b/frontend/content/organizations/tindok.md
@@ -6,11 +6,9 @@ image: /img/tindok3.jpg
 board:
   ceo:
     name: Fredrik Sollerud
-    mail:
     title: Turleder
   cto:
     name: Trym Wian
-    mail:
     title: Turleder
 tag: idrett
 ---

--- a/frontend/content/organizations/tindok.md
+++ b/frontend/content/organizations/tindok.md
@@ -3,15 +3,15 @@ title: Tindøk
 description: Bestiger Norges fjelltopper
 logo: /img/tindoklogo.png
 image: /img/tindok3.jpg
-styre:
+board:
   ceo:
-    navn: Fredrik Sollerud
+    name: Fredrik Sollerud
     mail:
-    tittel: Turleder
+    title: Turleder
   cto:
-    navn: Trym Wian
+    name: Trym Wian
     mail:
-    tittel: Turleder
+    title: Turleder
 tag: idrett
 ---
 

--- a/frontend/content/organizations/typisk.md
+++ b/frontend/content/organizations/typisk.md
@@ -6,11 +6,9 @@ image: /img/hero.jpg
 board:
   ceo:
     name: Jakob Fougner Engebretsen
-    mail:
     title: Podcasthost
   cto:
     name: Håkon Melgård Sveen
-    mail:
     title: Podcasthost
 tag: kultur
 ---

--- a/frontend/content/organizations/typisk.md
+++ b/frontend/content/organizations/typisk.md
@@ -3,15 +3,15 @@ title: Typisk Indøk
 description: Podcasten som umenneskeliggjør Indøkere
 logo: /img/typisk.jpg
 image: /img/hero.jpg
-styre:
+board:
   ceo:
-    navn: Jakob Fougner Engebretsen
+    name: Jakob Fougner Engebretsen
     mail:
-    tittel: Podcasthost
+    title: Podcasthost
   cto:
-    navn: Håkon Melgård Sveen
+    name: Håkon Melgård Sveen
     mail:
-    tittel: Podcasthost
+    title: Podcasthost
 tag: kultur
 ---
 

--- a/frontend/src/pages/about/organizations/[slug].tsx
+++ b/frontend/src/pages/about/organizations/[slug].tsx
@@ -1,12 +1,12 @@
 import Layout from "@components/Layout";
+import * as markdownComponents from "@components/markdown/components";
 import { Box, Card, Chip, Container, Divider, Grid, makeStyles, Paper, Typography } from "@material-ui/core";
 import MailOutlineIcon from "@material-ui/icons/MailOutline";
 import PhoneIcon from "@material-ui/icons/Phone";
 import { getPostBySlug, getPostsSlugs } from "@utils/posts";
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
-import React from "react";
+import Link from "next/link";
 import ReactMarkdown from "react-markdown";
-import * as markdownComponents from "@components/markdown/components";
 import { Post } from "src/types/posts";
 
 type ArticleProps = {
@@ -23,7 +23,7 @@ type ArticleProps = {
     logo?: string;
     alt?: string;
     image?: string;
-    board: BoardMember[];
+    board: Record<string, BoardMember>;
   };
   nextPost: Post | null;
   previousPost: Post | null;
@@ -101,17 +101,21 @@ const Article: NextPage<ArticleProps> = ({ post, frontmatter }) => {
                 <Typography variant="h5" gutterBottom>
                   Styret
                 </Typography>
-                {frontmatter.board.map((member, index) => (
+                {Object.entries(frontmatter.board).map(([key, member], index) => (
                   <>
                     {index != 0 && <Divider />}
-                    <Card key={index}>
+                    <Card key={key}>
                       <Box p={4}>
                         <Typography variant="body2">{member.name}</Typography>
                         <Typography variant="caption" gutterBottom>
                           {member.title}
                         </Typography>
                         <br />
-                        {member.mail && <Chip size="small" label={member.mail} icon={<MailOutlineIcon />} />}
+                        {member.mail && (
+                          <Link href={`mailto:${member.mail}`}>
+                            <Chip size="small" label={member.mail} icon={<MailOutlineIcon />} />
+                          </Link>
+                        )}
                         {member.mail && member.phoneNumber && <br />}
                         {member.phoneNumber && <Chip size="small" label={member.phoneNumber} icon={<PhoneIcon />} />}
                       </Box>


### PR DESCRIPTION
## Proposed Changes

#140 included adjusted typings for the organization markdown files, and in the process, something typed as `Array<any>` was changed to `BoardMember[]`, yet the actual type was `Record<string, BoardMember>`, which does not have a `.map` function. Furthermore, the name of the types no longer corresponded to the keys in the markdown files.

- Change all keys in the `.md` files to English.
- Fix the typing of `Frontmatter` 
- Add `mailto:` to the email field

## Types of Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR
### Before
<img width="1579" alt="Screen Shot 2021-11-21 at 14 56 36" src="https://user-images.githubusercontent.com/46653859/142764749-0ca9adbd-5cfc-46cf-b82c-742e4ac8c507.png">

### After
<img width="1579" alt="Screen Shot 2021-11-21 at 14 57 43" src="https://user-images.githubusercontent.com/46653859/142764786-942c6835-5893-439e-98af-a084c043c50f.png">

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
