### PR TITLE
🤖 ci(dependabot, dok-201): re-add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Keep npm dependencies up to date
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    # Check the npm registry for updates at 2am UTC
+    schedule:
+      interval: "daily"
+      time: "02:00"
+
+    commit-message:
+      prefix: "build(node): "
+
+    labels:
+      - "dependencies"
+      - "javascript"
+
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: "pip"
+    directory: "/backend/requirements/"
+    # Check the npm registry for updates at 2am UTC
+    schedule:
+      interval: "daily"
+      time: "02:00"
+
+    commit-message:
+      prefix: "build(python): "
+
+    labels:
+      - "dependencies"
+      - "python"
+
+    open-pull-requests-limit: 2


### PR DESCRIPTION
## Proposed Changes

Keeping our packages up to date is important. However, Dependabot cannot access secrets necessary for pulling images and such due to security concerns. In order to the checks to run, we have to manually re-run the CI jobs. Prior to the CI refactor, this was quite annoying as all workflows had to be re-run, but after the refactor, there's only one workflow to re-run.

I'll be the first to admit that this is not a clean solution by any means, but it's a temporary solution to an important issue.

- Re-add `dependabot.yml` for dependabot updates.

## Alternatives
- Scope up permissions to grant access to secrets, which is basically a regression of a security fix implemented by Github.
- De-couple the CI-pipeline completely from secrets, ECR, et cetera - would be great, but I am unsure how to go about this, especially considering the fact that NextJS requires build time variables.

## Types of Changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [x] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- DOK-201

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
