### PR TITLE
refactor event components on org admin page

### DIFF
--- a/frontend/src/components/pages/events/org/EventsExport.tsx
+++ b/frontend/src/components/pages/events/org/EventsExport.tsx
@@ -1,0 +1,93 @@
+import { Organization } from "@interfaces/organizations";
+import { Button, ButtonGroup, Grid, TextField, Typography, CircularProgress } from "@material-ui/core";
+import { useState } from "react";
+import { useLazyQuery } from "@apollo/client";
+import GetAppIcon from "@material-ui/icons/GetApp";
+import { QUERY_ATTENDEE_REPORTS, QUERY_ATTENDEE_REPORT_ORG } from "@graphql/events/queries";
+import { promptDownloadFromPayload } from "@utils/exports";
+
+type Props = {
+  organization: Organization;
+};
+
+const EventsExport: React.FC<Props> = ({ organization }) => {
+  const [selectedEvents, setSelectedEvents] = useState(["1", "2", "3"]);
+
+  const [getAttendeeReportOrg, { loading: loadingReport }] = useLazyQuery(QUERY_ATTENDEE_REPORT_ORG, {
+    onCompleted: (data) => promptDownloadFromPayload(JSON.parse(data.attendeeReportOrg)),
+  });
+
+  const [getAttendeeReports, { loading: loadingReports }] = useLazyQuery(QUERY_ATTENDEE_REPORTS, {
+    onCompleted: (data) => promptDownloadFromPayload(JSON.parse(data.attendeeReports)),
+  });
+
+  const wrapDownloadButtonReportOrg = (orgId: string, filetype: string) => {
+    return (
+      <Button
+        startIcon={<GetAppIcon fontSize="small" />}
+        onClick={() => getAttendeeReportOrg({ variables: { orgId: orgId, filetype: filetype } })}
+      >
+        {filetype}
+      </Button>
+    );
+  };
+
+  if (loadingReport || loadingReports) {
+    return <CircularProgress />;
+  }
+
+  const wrapDownloadButtonReports = (filetype: string) => {
+    return (
+      <Button
+        startIcon={<GetAppIcon fontSize="small" />}
+        disabled
+        onClick={() => {
+          return getAttendeeReports({ variables: { eventIds: selectedEvents, filetype: filetype } });
+        }}
+      >
+        {filetype}
+      </Button>
+    );
+  };
+
+  return (
+    <>
+      <Grid item xs={6}>
+        <Grid item xs={12}>
+          <Typography variant="overline" display="block">
+            Eksportér for alle mine arrangementer
+          </Typography>
+        </Grid>
+        <ButtonGroup variant="text" color="primary" aria-label="text primary button group">
+          <Grid item>{wrapDownloadButtonReportOrg(organization.id, "csv")}</Grid>
+          <Grid item>{wrapDownloadButtonReportOrg(organization.id, "xlsx")}</Grid>
+          <Grid item>{wrapDownloadButtonReportOrg(organization.id, "html")}</Grid>
+        </ButtonGroup>
+      </Grid>
+      <Grid item xs={6}>
+        <Grid item xs={12}>
+          <Typography variant="overline" display="block">
+            Eksportér for utvalgte arrangementer
+          </Typography>
+          <TextField
+            value={selectedEvents.join(",")}
+            onChange={(e) => setSelectedEvents(e.target.value.replace(/ /g, "").split(","))}
+            label="Selected event ID's"
+            size="small"
+            helperText="Comma-separated list of event ID's"
+            disabled
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <ButtonGroup variant="text" color="primary" aria-label="text primary button group">
+            <Grid item>{wrapDownloadButtonReports("csv")}</Grid>
+            <Grid item>{wrapDownloadButtonReports("xlsx")}</Grid>
+            <Grid item>{wrapDownloadButtonReports("html")}</Grid>
+          </ButtonGroup>
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+
+export default EventsExport;

--- a/frontend/src/components/pages/events/org/EventsExport.tsx
+++ b/frontend/src/components/pages/events/org/EventsExport.tsx
@@ -51,7 +51,7 @@ const EventsExport: React.FC<Props> = ({ organization }) => {
   };
 
   return (
-    <>
+    <Grid container>
       <Grid item xs={6}>
         <Grid item xs={12}>
           <Typography variant="overline" display="block">
@@ -86,7 +86,7 @@ const EventsExport: React.FC<Props> = ({ organization }) => {
           </ButtonGroup>
         </Grid>
       </Grid>
-    </>
+    </Grid>
   );
 };
 

--- a/frontend/src/components/pages/events/org/OrgEvents.tsx
+++ b/frontend/src/components/pages/events/org/OrgEvents.tsx
@@ -1,0 +1,18 @@
+import { Organization } from "@interfaces/organizations";
+import OrgEventsTable from "@components/pages/events/org/OrgEventsTable";
+import EventsExport from "@components/pages/events/org/EventsExport";
+
+type Props = {
+  organization: Organization;
+};
+
+const OrgEvents: React.FC<Props> = ({ organization }) => {
+  return (
+    <>
+      <OrgEventsTable organization={organization} />
+      <EventsExport organization={organization} />
+    </>
+  );
+};
+
+export default OrgEvents;

--- a/frontend/src/components/pages/events/org/OrgEventsTable.tsx
+++ b/frontend/src/components/pages/events/org/OrgEventsTable.tsx
@@ -44,7 +44,7 @@ const OrgEventsTable: React.FC<Props> = ({ organization }) => {
   const classes = useStyles();
 
   return (
-    <Grid item container>
+    <Grid container>
       <Grid item xs>
         <Card variant="outlined">
           <CardHeader title="Arrangementer" />

--- a/frontend/src/components/pages/events/org/OrgEventsTable.tsx
+++ b/frontend/src/components/pages/events/org/OrgEventsTable.tsx
@@ -1,0 +1,93 @@
+import { Organization } from "@interfaces/organizations";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  Chip,
+  Divider,
+  Grid,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  makeStyles,
+} from "@material-ui/core";
+import dayjs from "dayjs";
+import Link from "next/link";
+import { Event } from "@interfaces/events";
+
+interface HeaderValuePair<T> {
+  header: string;
+  field: keyof T;
+}
+
+const eventFields: HeaderValuePair<Event>[] = [
+  { header: "Navn", field: "title" },
+  { header: "Antall Plasser", field: "availableSlots" },
+];
+
+const useStyles = makeStyles(() => ({
+  hover: {
+    "&:hover": {
+      cursor: "pointer",
+    },
+  },
+}));
+
+type Props = {
+  organization: Organization;
+};
+
+const OrgEventsTable: React.FC<Props> = ({ organization }) => {
+  const classes = useStyles();
+
+  return (
+    <Grid item container>
+      <Grid item xs>
+        <Card variant="outlined">
+          <CardHeader title="Arrangementer" />
+          <Divider variant="middle" />
+          <CardContent>
+            <TableContainer>
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Dato</TableCell>
+                    {eventFields.map((field: HeaderValuePair<Event>) => (
+                      <TableCell key={`header-${field.header}`}>{field.header}</TableCell>
+                    ))}
+                    <TableCell>Antall påmeldte</TableCell>
+                    <TableCell>Status</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {(organization.events ?? []).map((event: Event) => (
+                    <Link href={`${organization.id}/events/${event.id}`} passHref key={event.id}>
+                      <TableRow className={classes.hover} hover>
+                        <TableCell>{dayjs(event.startTime).format("HH:mm DD-MM-YYYY")}</TableCell>
+                        {eventFields.map((field: HeaderValuePair<Event>) => (
+                          <TableCell key={`event-${event.id}-cell-${field.field}`}>{event[field.field]}</TableCell>
+                        ))}
+                        <TableCell>{event.usersAttending?.length}</TableCell>
+                        <TableCell>
+                          <Chip
+                            label={event.isFull ? "Fullt" : "Ledige Plasser"}
+                            color={event.isFull ? "default" : "secondary"}
+                          />
+                        </TableCell>
+                      </TableRow>
+                    </Link>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </CardContent>
+        </Card>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default OrgEventsTable;

--- a/frontend/src/components/pages/listings/organization/OrganizationListings.tsx
+++ b/frontend/src/components/pages/listings/organization/OrganizationListings.tsx
@@ -55,7 +55,7 @@ const OrganizationListings: React.FC<{
           setListingToDelete(undefined);
         }}
       />
-      <Grid item container>
+      <Grid container>
         <Grid item xs>
           <Card variant="outlined">
             <CardHeader title="Verv" />

--- a/frontend/src/pages/orgs/[orgId]/index.tsx
+++ b/frontend/src/pages/orgs/[orgId]/index.tsx
@@ -2,13 +2,11 @@ import { useQuery } from "@apollo/client";
 import Layout from "@components/Layout";
 import { GET_ORGANIZATION } from "@graphql/orgs/queries";
 import { Organization } from "@interfaces/organizations";
-import Link from "next/link";
-import { Box, CircularProgress, Grid, Typography, Button } from "@material-ui/core";
+import { Box, CircularProgress, Grid, Typography } from "@material-ui/core";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
 import OrganizationListings from "@components/pages/listings/organization/OrganizationListings";
 import OrgEvents from "@components/pages/events/org/OrgEvents";
-import { Person } from "@material-ui/icons";
 
 const OrganizationDetailPage: NextPage = () => {
   const router = useRouter();

--- a/frontend/src/pages/orgs/[orgId]/index.tsx
+++ b/frontend/src/pages/orgs/[orgId]/index.tsx
@@ -1,200 +1,44 @@
-import { useLazyQuery, useQuery } from "@apollo/client";
+import { useQuery } from "@apollo/client";
 import Layout from "@components/Layout";
-import { QUERY_ATTENDEE_REPORTS, QUERY_ATTENDEE_REPORT_ORG } from "@graphql/events/queries";
 import { GET_ORGANIZATION } from "@graphql/orgs/queries";
-import { Event } from "@interfaces/events";
 import { Organization } from "@interfaces/organizations";
-import {
-  Box,
-  Button,
-  ButtonGroup,
-  Card,
-  CardContent,
-  CardHeader,
-  Chip,
-  CircularProgress,
-  Divider,
-  Grid,
-  makeStyles,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  TextField,
-  Typography,
-} from "@material-ui/core";
-import GetAppIcon from "@material-ui/icons/GetApp";
-import { promptDownloadFromPayload } from "@utils/exports";
-import dayjs from "dayjs";
-import { NextPage } from "next";
 import Link from "next/link";
+import { Box, CircularProgress, Grid, Typography, Button } from "@material-ui/core";
+import { NextPage } from "next";
 import { useRouter } from "next/router";
-import { default as React, useState } from "react";
 import OrganizationListings from "@components/pages/listings/organization/OrganizationListings";
-
-interface HeaderValuePair<T> {
-  header: string;
-  field: keyof T;
-}
-
-const eventFields: HeaderValuePair<Event>[] = [
-  { header: "Navn", field: "title" },
-  { header: "Antall Plasser", field: "availableSlots" },
-];
-
-const useStyles = makeStyles(() => ({
-  hover: {
-    "&:hover": {
-      cursor: "pointer",
-    },
-  },
-}));
+import OrgEvents from "@components/pages/events/org/OrgEvents";
+import { Person } from "@material-ui/icons";
 
 const OrganizationDetailPage: NextPage = () => {
   const router = useRouter();
   const { orgId } = router.query;
   const orgNumberId = parseInt(orgId as string);
 
-  const [selectedEvents, setSelectedEvents] = useState(["1", "2", "3"]);
-
-  const [getAttendeeReportOrg, { loading: loadingReport }] = useLazyQuery(QUERY_ATTENDEE_REPORT_ORG, {
-    onCompleted: (data) => promptDownloadFromPayload(JSON.parse(data.attendeeReportOrg)),
-  });
-
-  const [getAttendeeReports, { loading: loadingReports }] = useLazyQuery(QUERY_ATTENDEE_REPORTS, {
-    onCompleted: (data) => promptDownloadFromPayload(JSON.parse(data.attendeeReports)),
-  });
-
-  const classes = useStyles();
-
-  const { data, loading } = useQuery<{ organization: Organization }, { orgId: number }>(GET_ORGANIZATION, {
+  const { data, loading, error } = useQuery<{ organization: Organization }, { orgId: number }>(GET_ORGANIZATION, {
     variables: { orgId: orgNumberId },
     skip: Number.isNaN(orgNumberId),
   });
 
-  if (loading || loadingReport || loadingReports) {
-    return <CircularProgress />;
-  }
-
-  const wrapDownloadButtonReportOrg = (orgId: number, filetype: string) => {
-    return (
-      <Button
-        startIcon={<GetAppIcon fontSize="small" />}
-        onClick={() => getAttendeeReportOrg({ variables: { orgId: orgId, filetype: filetype } })}
-      >
-        {filetype}
-      </Button>
-    );
-  };
-
-  const wrapDownloadButtonReports = (filetype: string) => {
-    return (
-      <Button
-        startIcon={<GetAppIcon fontSize="small" />}
-        disabled
-        onClick={() => {
-          return getAttendeeReports({ variables: { eventIds: selectedEvents, filetype: filetype } });
-        }}
-      >
-        {filetype}
-      </Button>
-    );
-  };
+  if (error) return <p>Error</p>;
+  if (loading) return <CircularProgress />;
 
   return (
     <Layout>
       <Box m={10}>
-        {data?.organization?.events ? (
-          <Grid container spacing={10}>
-            <Grid item>
-              <Typography variant="h1" align="center">
-                {data.organization.name}
-              </Typography>
-            </Grid>
-            <Grid item container>
-              <Grid item xs>
-                <Card variant="outlined">
-                  <CardHeader title="Arrangementer" />
-                  <Divider variant="middle" />
-                  <CardContent>
-                    <TableContainer>
-                      <Table>
-                        <TableHead>
-                          <TableRow>
-                            <TableCell>Dato</TableCell>
-                            {eventFields.map((field: HeaderValuePair<Event>) => (
-                              <TableCell key={`header-${field.header}`}>{field.header}</TableCell>
-                            ))}
-                            <TableCell>Antall påmeldte</TableCell>
-                            <TableCell>Status</TableCell>
-                          </TableRow>
-                        </TableHead>
-                        <TableBody>
-                          {data.organization.events.map((event: Event) => (
-                            <Link href={`${orgNumberId}/events/${event.id}`} passHref key={event.id}>
-                              <TableRow className={classes.hover} hover>
-                                <TableCell>{dayjs(event.startTime).format("HH:mm DD-MM-YYYY")}</TableCell>
-                                {eventFields.map((field: HeaderValuePair<Event>) => (
-                                  <TableCell key={`event-${event.id}-cell-${field.field}`}>
-                                    {event[field.field]}
-                                  </TableCell>
-                                ))}
-                                <TableCell>{event.usersAttending?.length}</TableCell>
-                                <TableCell>
-                                  <Chip
-                                    label={event.isFull ? "Fullt" : "Ledige Plasser"}
-                                    color={event.isFull ? "default" : "secondary"}
-                                  />
-                                </TableCell>
-                              </TableRow>
-                            </Link>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    </TableContainer>
-                  </CardContent>
-                </Card>
+        {data?.organization && (
+          <>
+            <Grid container spacing={5} direction="column" justifyContent="flex-start">
+              <Grid item>
+                <Typography variant="h1">{data.organization.name}</Typography>
+              </Grid>
+              <Grid item>{data.organization.events && <OrgEvents organization={data.organization} />}</Grid>
+              <Grid item>
+                {data.organization.listings && <OrganizationListings organization={data.organization} />}
               </Grid>
             </Grid>
-            <Grid item xs={6}>
-              <Grid item xs={12}>
-                <Typography variant="overline" display="block">
-                  Eksportér for alle mine arrangementer
-                </Typography>
-              </Grid>
-              <ButtonGroup variant="text" color="primary" aria-label="text primary button group">
-                <Grid item>{wrapDownloadButtonReportOrg(orgNumberId, "csv")}</Grid>
-                <Grid item>{wrapDownloadButtonReportOrg(orgNumberId, "xlsx")}</Grid>
-                <Grid item>{wrapDownloadButtonReportOrg(orgNumberId, "html")}</Grid>
-              </ButtonGroup>
-            </Grid>
-            <Grid item xs={6}>
-              <Grid item xs={12}>
-                <Typography variant="overline" display="block">
-                  Eksportér for utvalgte arrangementer
-                </Typography>
-                <TextField
-                  value={selectedEvents.join(",")}
-                  onChange={(e) => setSelectedEvents(e.target.value.replace(/ /g, "").split(","))}
-                  label="Selected event ID's"
-                  size="small"
-                  helperText="Comma-separated list of event ID's"
-                  disabled
-                />
-              </Grid>
-              <Grid item xs={12}>
-                <ButtonGroup variant="text" color="primary" aria-label="text primary button group">
-                  <Grid item>{wrapDownloadButtonReports("csv")}</Grid>
-                  <Grid item>{wrapDownloadButtonReports("xlsx")}</Grid>
-                  <Grid item>{wrapDownloadButtonReports("html")}</Grid>
-                </ButtonGroup>
-              </Grid>
-            </Grid>
-            {data?.organization?.listings && <OrganizationListings organization={data.organization} />}
-          </Grid>
-        ) : null}
+          </>
+        )}
       </Box>
     </Layout>
   );


### PR DESCRIPTION
## Proposed Changes

- Restructure org admin page file by separating event-related stuff to their own components, to make it more readable
- Fix some uses of Grid

This PR only restructures files, and should not affect functionality.

## Types of Changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement/optimization
- [x] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
