### PR TITLE
fix: set fallback function if sentry import fails

### DIFF
--- a/backend/apps/ecommerce/vipps_utils.py
+++ b/backend/apps/ecommerce/vipps_utils.py
@@ -10,7 +10,7 @@ try:
     from sentry_sdk import set_context
 except ModuleNotFoundError:
 
-    def set_context(*_):
+    def set_context(*args, **kwargs):
         pass
 
 

--- a/backend/apps/ecommerce/vipps_utils.py
+++ b/backend/apps/ecommerce/vipps_utils.py
@@ -5,7 +5,14 @@ from typing import Literal, Optional, Tuple, TypedDict
 import requests
 from django.conf import settings
 from django.utils import timezone
-from sentry_sdk import set_context
+
+try:
+    from sentry_sdk import set_context
+except ModuleNotFoundError:
+
+    def set_context(*_):
+        pass
+
 
 from .models import Order, VippsAccessToken
 

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -9,7 +9,6 @@ django-phonenumber-field==5.0.0
 django-ses==2.3.1
 djangorestframework==3.12.4
 factory-boy==3.2.0
-flake8==4.0.1
 graphene==2.1.8
 graphene-django==2.15.0
 gunicorn==20.0.4


### PR DESCRIPTION
## Proposed Changes

- The Sentry SDK is not installed for local builds of the application, causing the import to fail. This PR addresses the issue by setting a filler function if the import fails.
- Removes redundant flake8 from `base.txt`-requirements

## Types of Changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [x] Other

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [ ] I am pleased with the readability of the code (if not, state where you need input)
- [ ] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
