### PR TITLE
feat: graduation year validation, always show users' graduation year

### DIFF
--- a/frontend/src/components/pages/profile/UserForm/helpers.ts
+++ b/frontend/src/components/pages/profile/UserForm/helpers.ts
@@ -3,6 +3,7 @@ import * as Yup from "yup";
 
 const today = dayjs();
 export const maxGraduationYear = today.month() > 7 ? today.year() + 5 : today.year() + 4;
+const minGraduationYear = today.month() > 7 ? today.year() + 1 : today.year();
 
 export const suggestNames = (name: string | undefined): { firstName: string; lastName: string } => {
   if (!name) {
@@ -26,7 +27,10 @@ export const validationSchema = Yup.object().shape({
   lastName: Yup.string().required("Etternavn kan ikke være tomt.").min(2, "Kan ikke være kortere enn to tegn."),
   email: Yup.string().email("Oppgi en gyldig e-postadresse.").notRequired(),
   allergies: Yup.string().notRequired(),
-  graduationYear: Yup.number().required().min(today.year()).max(maxGraduationYear),
+  graduationYear: Yup.number()
+    .required()
+    .min(minGraduationYear, `Kan ikke være før ${minGraduationYear}`)
+    .max(maxGraduationYear, `Kan ikke være etter ${maxGraduationYear}`),
   phoneNumber: Yup.string()
     .min(8, "Telefonnummeret må være 8 tegn eller lenger.")
     .max(12, "Telefonnummeret kan ikke være mer enn 12 tegn.")

--- a/frontend/src/components/pages/profile/UserForm/index.tsx
+++ b/frontend/src/components/pages/profile/UserForm/index.tsx
@@ -28,6 +28,7 @@ import dayjs from "dayjs";
 import { useFormik } from "formik";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import { useMemo } from "react";
 import { EditUser } from "src/types/users";
 import { suggestNames } from "./helpers";
 
@@ -49,6 +50,14 @@ const UserForm: React.VFC<Props> = ({ kind, title, onCompleted, "data-test-id": 
   const ID_PREFIX = `${dataTestId}`;
 
   const { firstName, lastName } = suggestNames(data?.user?.firstName);
+  const minimumGraduationYear = useMemo<number>(
+    () => Math.min(currentYear, data?.user?.graduationYear || currentYear),
+    [data?.user?.graduationYear]
+  );
+  const graduationYears = useMemo<number[]>(
+    () => range(minimumGraduationYear, maxGraduationYear, 1),
+    [minimumGraduationYear]
+  );
 
   const formik = useFormik({
     initialValues: {
@@ -182,12 +191,17 @@ const UserForm: React.VFC<Props> = ({ kind, title, onCompleted, "data-test-id": 
                   data-test-id={`${ID_PREFIX}graduationYearSelect`}
                   disabled={!data?.user?.canUpdateYear}
                 >
-                  {range(currentYear, maxGraduationYear, 1).map((year) => (
+                  {graduationYears.map((year) => (
                     <option key={year} value={year}>
                       {year}
                     </option>
                   ))}
                 </NativeSelect>
+                {formik.touched.graduationYear && Boolean(formik.errors.graduationYear) && (
+                  <FormHelperText style={{ color: theme.palette.error.main }}>
+                    {formik.touched.graduationYear && formik.errors.graduationYear}
+                  </FormHelperText>
+                )}
                 {data?.user?.canUpdateYear && <FormHelperText>Kan bare endres én gang i året.</FormHelperText>}
                 {!data?.user?.canUpdateYear && (
                   <FormHelperText>


### PR DESCRIPTION
## Proposed Changes

- Always show a users' current graduation year, even if it's not a legal value
- Improve validation

## Types of Changes

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement/optimization
- [ ] Refactor
- [x] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- Users with a graduation year < the current year might be confused when trying to change, as the selector defaults to one of the permitted values. This fixes that issue by showing users their currently selected year, even if it's an illegal value.

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
