### PR TITLE
Send an order confirmation e-mail upon successfull Vipps payment

### DIFF
--- a/backend/apps/ecommerce/__init__.py
+++ b/backend/apps/ecommerce/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "apps.ecommerce.apps.EcommerceConfig"

--- a/backend/apps/ecommerce/apps.py
+++ b/backend/apps/ecommerce/apps.py
@@ -3,3 +3,8 @@ from django.apps import AppConfig
 
 class EcommerceConfig(AppConfig):
     name = "apps.ecommerce"
+
+    def ready(self) -> None:
+        import apps.ecommerce.signals  # noqa
+
+        return super().ready()

--- a/backend/apps/ecommerce/mail.py
+++ b/backend/apps/ecommerce/mail.py
@@ -1,0 +1,57 @@
+from typing import TypedDict
+
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import get_template
+from django.utils.html import strip_tags
+
+from .models import Order
+
+
+class EmailInput(TypedDict):
+    first_name: str
+    last_name: str
+    order_id: str
+    timestamp: str
+    product: str
+    quantity: int
+    price: float
+
+
+def send_order_confirmation_mail(order: Order) -> None:
+    """
+    Send an order confirmation upon capturing an order. The email is sent to the
+    preferred email adress stored on the user that initiated the order.
+
+    Args:
+        order (Order): Order to send confirmation for
+    """
+
+    assert order.payment_status == Order.PaymentStatus.CAPTURED
+    user = order.user
+
+    content: EmailInput = {
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "order_id": order.id,
+        "timestamp": order.timestamp.strftime("%d.%m.%Y, %H:%M:%S"),
+        "product": order.product.name,
+        "quantity": order.quantity,
+        "price": order.total_price,
+    }
+
+    # HTML content for mail services supporting HTML, text content if HTML isn't supported
+    html_content = get_template("ecommerce/order_confirmation.html").render(content)
+    text_content = strip_tags(html_content)
+
+    subject = f"Ordrebekreftelse - {order.product.name} - indokntnu.no"
+
+    email = EmailMultiAlternatives(
+        subject,
+        body=text_content,
+        from_email="noreply@indokntnu.no",
+        to=[order.user.email],
+    )
+    email.mixed_subtype = "related"
+    email.attach_alternative(html_content, "text/html")
+
+    email.send()

--- a/backend/apps/ecommerce/mail.py
+++ b/backend/apps/ecommerce/mail.py
@@ -51,7 +51,6 @@ def send_order_confirmation_mail(order: Order) -> None:
         from_email="noreply@indokntnu.no",
         to=[order.user.email],
     )
-    email.mixed_subtype = "related"
     email.attach_alternative(html_content, "text/html")
 
     email.send()

--- a/backend/apps/ecommerce/signals.py
+++ b/backend/apps/ecommerce/signals.py
@@ -1,0 +1,21 @@
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from .mail import send_order_confirmation_mail
+from .models import Order
+
+
+@receiver(pre_save, sender=Order)
+def send_order_confirmation(sender, instance: Order, **kwargs):
+    """
+    Send an order confirmation email when an order is captured.
+    An order is captured when the payment status is changed from RESERVED to CAPTURED
+    """
+    # Check that we are updating an order, not creating
+    if not instance._state.adding:
+        previous: Order = sender.objects.get(id=instance.id)
+        if (
+            previous.payment_status == Order.PaymentStatus.RESERVED
+            and instance.payment_status == Order.PaymentStatus.CAPTURED
+        ):
+            send_order_confirmation_mail(instance)

--- a/backend/templates/ecommerce/order_confirmation.html
+++ b/backend/templates/ecommerce/order_confirmation.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+
+<html lang="no">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title></title>
+    <meta name="description" content="" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="" />
+
+    <style>
+      span {
+        white-space: nowrap;
+      }
+
+      @media (min-width: 1000px) {
+        .contentDiv {
+          margin: 20px auto;
+          width: 80%;
+        }
+      }
+    </style>
+  </head>
+  <body style="font-family: Open Sans, sans-serif">
+    <div
+      style="
+        border: 5px solid #065a5a;
+        text-align: center;
+        padding: 50px;
+        background-color: #f5f0eb;
+        width: 80%;
+      "
+      class="contentDiv"
+    >
+      {% load static %}
+
+      <h2>Hei {{ first_name }} {{last_name}}!</h2>
+      <p>
+        Dette er en ordrebekreftelse på ditt kjøp på
+        <a href="https://indokntnu.no">indokntnu.no</a>. Din ordre-ID er
+        <strong>{{ order_id }}</strong>.
+      </p>
+      <p>
+        Du kan til enhver tid finne tilsvarende ordrebekreftelse på nettisden på
+        <a
+          href="https://indokntnu.no/ecommerce/fallback?orderId={{ order_id }}&redirect=/ecommerce"
+          >denne linken</a
+        >.
+      </p>
+      <h2>Din bestilling</h2>
+      <p>
+        <strong>Bestillingsdato:</strong> {{ timestamp }} <br />
+        <strong>Ordre-ID:</strong> {{ order_id }} <br />
+        <strong>Betalingsform:</strong> Vipps
+      </p>
+      <p>
+        Produkt:
+        <span><strong>{{ product }}</strong></span> - {{ quantity }}stk á
+        <strong>kr {{ price }}</strong>
+      </p>
+      <h3>Totalpris: <strong>kr {{ price }}</strong></h3>
+      <hr />
+      <p>
+        Se en oversikt over alle dine ordrer på
+        <a href="https://indokntnu.no/ecommerce">denne linken</a> (krever
+        innlogging).
+      </p>
+      <p>Ikke nøl med å ta kontakt om du skulle ha spørsmål.</p>
+      <p>Med vennlig hilsen,</p>
+      <p>
+        Rubberdøk <br />
+        <a href="mailto:kontakt@rubberdok.no"></a>kontakt@rubberdok.no <br /><a
+          href="https://indokntnu.no"
+          >indokntnu.no</a
+        >
+      </p>
+      <img
+        src="https://raw.githubusercontent.com/rubberdok/indok-web/docs/assets/rubberdok_logo_signature.png"
+        alt="logo image"
+        width="200"
+      />
+    </div>
+  </body>
+</html>

--- a/backend/templates/ecommerce/order_confirmation.html
+++ b/backend/templates/ecommerce/order_confirmation.html
@@ -76,7 +76,7 @@
         >
       </p>
       <img
-        src="https://raw.githubusercontent.com/rubberdok/indok-web/docs/assets/rubberdok_logo_signature.png"
+        src="https://indokweb-assets.s3.eu-north-1.amazonaws.com/mail/logo_signature.png"
         alt="logo image"
         width="200"
       />

--- a/frontend/src/pages/ecommerce/checkout.tsx
+++ b/frontend/src/pages/ecommerce/checkout.tsx
@@ -93,8 +93,8 @@ const CheckoutPage: NextPage = () => {
                 <Grid item xs={12}>
                   <Alert variant="filled" severity="info">
                     Betalingsløsningen er under utvikling. Dersom du opplever problemer, kontakt{" "}
-                    <a style={{ color: "blue" }} href="mailto:feedback@rubberdok.no">
-                      feedback@rubberdok.no
+                    <a style={{ color: "blue" }} href="mailto:kontakt@rubberdok.no">
+                      kontakt@rubberdok.no
                     </a>
                   </Alert>
                 </Grid>

--- a/frontend/src/pages/ecommerce/index.tsx
+++ b/frontend/src/pages/ecommerce/index.tsx
@@ -66,8 +66,8 @@ const OrdersPage: NextPage = () => {
                 <Grid item xs={12}>
                   <Alert variant="filled" severity="info">
                     Betalingsløsningen er under utvikling. Dersom du opplever problemer, kontakt{" "}
-                    <a style={{ color: "blue" }} href="mailto:feedback@rubberdok.no">
-                      feedback@rubberdok.no
+                    <a style={{ color: "blue" }} href="mailto:kontakt@rubberdok.no">
+                      kontakt@rubberdok.no
                     </a>
                   </Alert>
                 </Grid>


### PR DESCRIPTION
## Proposed Changes

- Send an order confirmation email when an order is captured. The email currently looks like this:
![image](https://user-images.githubusercontent.com/37716832/151709574-b15a2f4a-1e7e-4278-9a7e-575dcf55932e.png)


## Types of Changes

- [x] New feature
- [ ] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- closes #401 

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
