### PR TITLE
Avoid keyError when setting Sentry context and unroll all changes upon initate payment failure

### DIFF
--- a/backend/apps/ecommerce/mutations.py
+++ b/backend/apps/ecommerce/mutations.py
@@ -33,12 +33,13 @@ class InitiateOrder(graphene.Mutation):
         if product.related_object and not product.related_object.is_user_allowed_to_buy_product(user):
             raise PurchaseNotAllowedError("Du kan ikke kjøpe dette produktet.")
 
-        # Reserve quantity for the user if available
-        product = Product.check_and_reserve_quantity(product_id, user, quantity)
+        # If any of the below fails, do not commit any DB transactions
+        with transaction.atomic():
+            # Reserve quantity for the user if available
+            product = Product.check_and_reserve_quantity(product_id, user, quantity)
 
-        # If the user has attempted this order before, retry it
-        try:
-            with transaction.atomic():
+            # If the user has attempted this order before, retry it
+            try:
                 # TODO: handle multiple hits (shouldn't happen as we retry)
                 order = Order.objects.select_for_update().get(
                     product__id=product_id,
@@ -82,12 +83,12 @@ class InitiateOrder(graphene.Mutation):
                 order.payment_status = Order.PaymentStatus.INITIATED
                 order.save()
 
-        except Order.DoesNotExist:
-            order = Order(product=product, user=user, quantity=quantity, total_price=product.price * quantity)
+            except Order.DoesNotExist:
+                order = Order(product=product, user=user, quantity=quantity, total_price=product.price * quantity)
 
-            order.save()
+                order.save()
 
-        redirect = InitiateOrder.vipps_api.initiate_payment(order, fallback_redirect)
+            redirect = InitiateOrder.vipps_api.initiate_payment(order, fallback_redirect)
 
         return InitiateOrder(redirect=redirect)
 

--- a/backend/apps/ecommerce/tests.py
+++ b/backend/apps/ecommerce/tests.py
@@ -266,7 +266,6 @@ class EcommerceMutationsTestCase(EcommerceBaseTestCase):
 
     @patch(INITIATE_PAYMENT_PATH)
     def test_handle_vipps_errors_on_initiate(self, initiate_payment_mock: MagicMock):
-        print(initiate_payment_mock)
         initiate_payment_mock.side_effect = requests.exceptions.HTTPError()
         unique_user = IndokUserFactory()
         prev_quantity = self.product_1.current_quantity

--- a/backend/apps/ecommerce/tests.py
+++ b/backend/apps/ecommerce/tests.py
@@ -2,6 +2,7 @@ import decimal
 import json
 from typing import Optional
 from unittest.mock import MagicMock, patch
+import requests
 
 from utils.testing.base import ExtendedGraphQLTestCase
 from utils.testing.factories.ecommerce import OrderFactory, ProductFactory
@@ -262,6 +263,16 @@ class EcommerceMutationsTestCase(EcommerceBaseTestCase):
         self.query(self.INITIATE_ORDER_MUTATION(self.max_buyable_quantity), user=unique_user)
         order: Order = Order.objects.get(user=unique_user, product=self.product_1)
         self.assertEqual(cancel_transaction_mock.call_args.args[0], f"{order.id}-1")
+
+    @patch(INITIATE_PAYMENT_PATH)
+    def test_handle_vipps_errors_on_initiate(self, initiate_payment_mock: MagicMock):
+        print(initiate_payment_mock)
+        initiate_payment_mock.side_effect = requests.exceptions.HTTPError()
+        unique_user = IndokUserFactory()
+        prev_quantity = self.product_1.current_quantity
+        self.query(self.INITIATE_ORDER_MUTATION(self.max_buyable_quantity), user=unique_user)
+        self.assertEquals(prev_quantity, self.product_1.current_quantity)
+        self.assertFalse(Order.objects.filter(user=unique_user).exists())
 
     @patch(CAPTURE_PAYMENT_PATH)
     @patch(PAYMENT_STATUS_PATH("AttemptCapturePayment"))

--- a/backend/apps/ecommerce/tests.py
+++ b/backend/apps/ecommerce/tests.py
@@ -271,7 +271,8 @@ class EcommerceMutationsTestCase(EcommerceBaseTestCase):
         unique_user = IndokUserFactory()
         prev_quantity = self.product_1.current_quantity
         self.query(self.INITIATE_ORDER_MUTATION(self.max_buyable_quantity), user=unique_user)
-        self.assertEquals(prev_quantity, self.product_1.current_quantity)
+        product: Product = Product.objects.get(pk=self.product_1.id)
+        self.assertEqual(prev_quantity, product.current_quantity)
         self.assertFalse(Order.objects.filter(user=unique_user).exists())
 
     @patch(CAPTURE_PAYMENT_PATH)

--- a/backend/apps/ecommerce/vipps_utils.py
+++ b/backend/apps/ecommerce/vipps_utils.py
@@ -129,7 +129,10 @@ class VippsApi:
         try:
             r.raise_for_status()
         except requests.exceptions.HTTPError as e:
-            set_context("vipps_error", r.json()[0])
+            if isinstance(r.json(), list):
+                set_context("vipps_error", r.json()[0])
+            elif isinstance(r.json(), dict):
+                set_context("vipps_error", r.json())
             raise e
 
     # Public methods:


### PR DESCRIPTION
## Proposed Changes

- Regarding Vipps errors,[ from docs](https://github.com/vippsas/vipps-ecom-api/blob/master/vipps-ecom-api.md#http-response-codes):
> HTTP responses with errors from the application gateway contain one error JSON object. Error responses produced from the application gateway include `401`, `403`, `422` and `429`.
HTTP responses with errors from the Vipps backend will contain an _array_ of JSON objects.
- This PR checks if an error from vipps is an object or an array of objects before setting context for sentry debugging.
- Additionally, the entire logic for initiating a payment is now encapsulated in an atomic block to ensure that a new order (or a +1 `payment_attempt`) is not saved if we fail to initiate the payment, along with any reserved quantity.

## Types of Changes

- [ ] New feature
- [x] Bug fix
- [x] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

-

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
