### PR TITLE
fix: never fetch instantiated `access_token`

### DIFF
--- a/backend/apps/ecommerce/vipps_utils.py
+++ b/backend/apps/ecommerce/vipps_utils.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import Any, Literal, Optional, Tuple, TypedDict
+from typing import Literal, Optional, Tuple, TypedDict, Union
 
 import requests
 from django.conf import settings
@@ -26,7 +26,9 @@ BaseHeaders = TypedDict(
         "Merchant-Serial-Number": str,
         "Vipps-System-Name": str,
         "Vipps-System-Version": str,
+        "X-Request-Id": str,
     },
+    total=False,
 )
 
 
@@ -84,7 +86,6 @@ class VippsApi:
         vipps_subscription_key: str = settings.VIPPS_SUBSCRIPTION_KEY,
         merchant_serial_number: str = settings.VIPPS_MERCHANT_SERIAL_NUMBER,
         vipps_server: str = settings.VIPPS_BASE_URL,
-        access_token: Optional[str] = None,
         vipps_system_name: Optional[str] = None,
         vipps_system_version: Optional[str] = None,
         vipps_system_plugin_name: Optional[str] = None,
@@ -95,14 +96,17 @@ class VippsApi:
         self.vipps_subscription_key = vipps_subscription_key
         self.merchant_serial_number = merchant_serial_number
         self.vipps_server = vipps_server
-        self._access_token = access_token
         self.vipps_system_name = vipps_system_name
         self.vipps_system_version = vipps_system_version
         self.vipps_system_plugin_name = vipps_system_plugin_name
         self.vipps_system_plugin_version = vipps_system_plugin_version
 
     def _make_call(
-        self, method: Literal["POST", "GET", "PUT"], endpoint: str, headers: dict[str, Any], data: Optional[dict] = None
+        self,
+        method: Literal["POST", "GET", "PUT"],
+        endpoint: str,
+        headers: Union[BaseHeaders, dict[str, str]],
+        data: Optional[str] = None,
     ) -> dict:
         """Used in main api calls
         Args:
@@ -113,7 +117,6 @@ class VippsApi:
         Returns:
             dict: response body as a dict
         """
-
         if method == "GET":
             req = requests.get
         elif method == "POST":
@@ -124,10 +127,10 @@ class VippsApi:
         url = f"{self.vipps_server}{endpoint}"
 
         r = req(url, headers=headers, data=data)
-        if r.ok:
-            return r.json()
+
         try:
             r.raise_for_status()
+            return r.json()
         except requests.exceptions.HTTPError as e:
             if isinstance(r.json(), list):
                 set_context("vipps_error", r.json()[0])
@@ -174,7 +177,7 @@ class VippsApi:
 
     # private methods
 
-    def _refresh_access_token(self) -> Tuple[str, str]:
+    def _refresh_access_token(self) -> Tuple[str, datetime.datetime]:
         # Get new access token from Vipps (expires after 1h/24h test/prod)
 
         headers = {
@@ -189,30 +192,23 @@ class VippsApi:
         expires_on = timezone.make_aware(datetime.datetime.fromtimestamp(int(token_response["expires_on"])))
         return access_token, expires_on
 
-    def _fetch_access_token(self) -> None:
-        # Get Vipps access token from db or fetch new if necessary
-        tokens = VippsAccessToken.objects
-        if not tokens.filter(expires_on__gte=timezone.now()).exists():
-            # No valid token in database, delete all stale tokens and get new token
-            if tokens.exists():
-                tokens.all().delete()
-            new_token = VippsAccessToken()
-            self._access_token, expires_on = self._refresh_access_token()
-            new_token.token = self._access_token
-            new_token.expires_on = expires_on
-            new_token.save()
-
-        self._access_token = tokens.filter(expires_on__gte=timezone.now()).first().token
-
     @property
     def access_token(self) -> str:
         """Checks if access token already obtained
         Returns:
             str: Access Token
         """
-        if self._access_token is None:
-            self._fetch_access_token()
-        return self._access_token
+        valid_token: Optional[VippsAccessToken] = VippsAccessToken.objects.filter(
+            expired_on__gte=timezone.now() + timezone.timedelta(minutes=5)
+        ).first()
+        if valid_token is None:
+            # No valid token in database, delete all stale tokens and get new token
+            VippsAccessToken.objects.all().delete()
+            token, expires_on = self._refresh_access_token()
+            valid_token = VippsAccessToken(token=token, expires_on=expires_on)
+            valid_token.save()
+
+        return valid_token.token
 
     def _build_headers(self) -> BaseHeaders:
         # Headers for Vipps requests

--- a/backend/apps/ecommerce/vipps_utils.py
+++ b/backend/apps/ecommerce/vipps_utils.py
@@ -199,7 +199,7 @@ class VippsApi:
             str: Access Token
         """
         valid_token: Optional[VippsAccessToken] = VippsAccessToken.objects.filter(
-            expired_on__gte=timezone.now() + timezone.timedelta(minutes=5)
+            expires_on__gte=timezone.now() + timezone.timedelta(minutes=5)
         ).first()
         if valid_token is None:
             # No valid token in database, delete all stale tokens and get new token


### PR DESCRIPTION
## Proposed Changes

- Django shares instantiated classes across processes, and it is therefore possible that users might receive an outdated Vipps access token, see #436 
- Clean up typing in `VippsApi`

## Types of Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- Closes #436
- Fixes INDOKWEB-BACKEND-2A

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
