### PR TITLE
build(node): bump node to 16.13.2, optimize NextJS builds

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Larger base image for development
-FROM --platform=linux/amd64 node:14
+FROM --platform=linux/amd64 node:16.13.2
 
 WORKDIR /app
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -51,16 +51,12 @@ ENV NEXT_PUBLIC_APP_ENV $APP_ENV
 RUN addgroup -g 1001 -S nodejs
 RUN adduser -S nextjs -u 1001
 
-RUN mkdir -p /usr/src/app/.next/cache/images && chown nextjs:nodejs /usr/src/app/.next/cache/images
-VOLUME /usr/src/app/.next/cache/images
-
 COPY --from=builder /usr/src/app/next.config.js ./
 COPY --from=builder /usr/src/app/public ./public
 COPY --from=builder /usr/src/app/package.json ./package.json
 
-# You only need to copy next.config.js if you are NOT using the default configuration
 COPY --from=builder --chown=nextjs:nodejs /usr/src/app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /usr/src/app/.next/static ./.next/standalone/static
+COPY --from=builder --chown=nextjs:nodejs /usr/src/app/.next/static ./.next/static
 
 USER nextjs
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -2,7 +2,7 @@
 ARG APP_ENV=production
 
 # Install dependencies only when needed
-FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/node:14-alpine AS deps
+FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/node:16.13.2-alpine AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /usr/src/app
@@ -10,7 +10,7 @@ COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 # Rebuild the source code only when needed
-FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/node:14-alpine AS builder
+FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/node:16.13.2-alpine AS builder
 WORKDIR /usr/src/app
 COPY . .
 COPY --from=deps /usr/src/app/node_modules ./node_modules
@@ -41,7 +41,7 @@ RUN yarn build \
     && yarn install --production --ignore-scripts --prefer-offline
 
 # Production image, copy all the files and run next
-FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/node:14-alpine AS runner
+FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/node:16.13.2-alpine AS runner
 WORKDIR /usr/src/app
 
 ARG APP_ENV

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -59,8 +59,8 @@ COPY --from=builder /usr/src/app/public ./public
 COPY --from=builder /usr/src/app/package.json ./package.json
 
 # You only need to copy next.config.js if you are NOT using the default configuration
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /usr/src/app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /usr/src/app/.next/static ./.next/standalone/static
 
 USER nextjs
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -12,8 +12,8 @@ RUN yarn install --frozen-lockfile
 # Rebuild the source code only when needed
 FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/node:16.13.2-alpine AS builder
 WORKDIR /usr/src/app
-COPY . .
 COPY --from=deps /usr/src/app/node_modules ./node_modules
+COPY . .
 
 ARG NEXT_PUBLIC_GRAPHQL_BACKEND_URI
 ENV NEXT_PUBLIC_GRAPHQL_BACKEND_URI $NEXT_PUBLIC_GRAPHQL_BACKEND_URI
@@ -37,12 +37,13 @@ ARG APP_ENV
 ENV NEXT_PUBLIC_APP_ENV $APP_ENV
 ENV BABEL_ENV $APP_ENV
 
-RUN yarn build \
-    && yarn install --production --ignore-scripts --prefer-offline
+RUN yarn build 
 
 # Production image, copy all the files and run next
 FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/node:16.13.2-alpine AS runner
 WORKDIR /usr/src/app
+
+ENV NODE_ENV production
 
 ARG APP_ENV
 ENV NEXT_PUBLIC_APP_ENV $APP_ENV
@@ -53,12 +54,13 @@ RUN adduser -S nextjs -u 1001
 RUN mkdir -p /usr/src/app/.next/cache/images && chown nextjs:nodejs /usr/src/app/.next/cache/images
 VOLUME /usr/src/app/.next/cache/images
 
-# You only need to copy next.config.js if you are NOT using the default configuration
 COPY --from=builder /usr/src/app/next.config.js ./
 COPY --from=builder /usr/src/app/public ./public
-COPY --from=builder --chown=nextjs:nodejs /usr/src/app/.next ./.next
-COPY --from=builder /usr/src/app/node_modules ./node_modules
 COPY --from=builder /usr/src/app/package.json ./package.json
+
+# You only need to copy next.config.js if you are NOT using the default configuration
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 
@@ -67,4 +69,4 @@ EXPOSE 3000
 # Disabled NextJS telemetry
 ENV NEXT_TELEMETRY_DISABLED 1
 
-CMD ["yarn", "start"]
+CMD ["node", "server.js"]

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -34,6 +34,7 @@ const moduleExports = {
     styledComponents: true,
     ...getPresets(),
   },
+  swcMinify: true,
   webpack: (config, { isServer }) => {
     // In `pages/_app.js`, Sentry is imported from @sentry/browser. While
     // @sentry/node will run in a Node.js environment. @sentry/node will use

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -31,6 +31,7 @@ const moduleExports = {
     ];
   },
   experimental: {
+    outputStandalone: true,
     styledComponents: true,
     ...getPresets(),
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "yup": "^0.32.9"
   },
   "devDependencies": {
-    "@types/node": "^14.17.3",
+    "@types/node": "^16.11.22",
     "@types/react": "^17.0.11",
     "@types/react-dom": "^17.0.8",
     "@types/react-swipeable-views": "^0.13.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -721,10 +721,10 @@
   dependencies:
     "@types/unist" "*"
 
-"@types/node@^14.17.3":
-  version "14.17.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.21.tgz#6359d8cf73481e312a43886fa50afc70ce5592c6"
-  integrity sha512-zv8ukKci1mrILYiQOwGSV4FpkZhyxQtuFWGya2GujWg+zVAeRQ4qbaMmWp9vb9889CFA8JECH7lkwCL6Ygg8kA==
+"@types/node@^16.11.22":
+  version "16.11.22"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.22.tgz#e704150225bfc4195f8ce68a7ac8da02b753549a"
+  integrity sha512-DYNtJWauMQ9RNpesl4aVothr97/tIJM8HbyOXJ0AYT1Z2bEjLHyfjOBPAQQVMLf8h3kSShYfNk8Wnto8B2zHUA==
 
 "@types/prop-types@*":
   version "15.7.4"


### PR DESCRIPTION
## Proposed Changes

- Bump Node to 16.13.2 (lts)
- Utilize [output file tracing](https://nextjs.org/docs/advanced-features/output-file-tracing) for smaller images
- Add `swcMinify: true` for improved build speeds
- All in all, shaves off about a minute or two from the build times ⚡️

## Types of Changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [x] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

-

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
