### PR TITLE
Avoid rendering duplicate hasBoughtTicket icons

### DIFF
--- a/frontend/src/pages/orgs/[orgId]/events/[eventId].tsx
+++ b/frontend/src/pages/orgs/[orgId]/events/[eventId].tsx
@@ -87,8 +87,6 @@ const EventAdminPage: NextPage = () => {
     return <CircularProgress />;
   }
 
-  data && data.event.product && signUpFields.push({ header: "Betalt?", field: "hasBoughtTicket" });
-
   const renderInfo = (label: string, value: string | boolean) => {
     if (value === "") {
       return;
@@ -181,7 +179,7 @@ const EventAdminPage: NextPage = () => {
                     <AttendeeExport eventId={eventNumberID} />
                   </CardActions>
                   <CardContent>
-                    {data?.event?.usersAttending?.length !== 0 ? (
+                    {data.event?.usersAttending?.length !== 0 ? (
                       <TableContainer style={{ maxHeight: 600 }}>
                         <Table>
                           <TableHead>
@@ -189,17 +187,23 @@ const EventAdminPage: NextPage = () => {
                               {signUpFields.map((field) => (
                                 <TableCell key={`user-header-${field.header}`}>{field.header}</TableCell>
                               ))}
+                              {data.event.product && <TableCell>Betalt?</TableCell>}
                               <TableCell key={`user-header-delete`} />
                             </TableRow>
                           </TableHead>
                           <TableBody>
-                            {data?.event?.usersAttending?.map((signUp: SignUp) => (
+                            {data.event?.usersAttending?.map((signUp: SignUp) => (
                               <TableRow key={`user-row-${signUp.user.id}`}>
                                 {signUpFields.map((field) => (
                                   <TableCell key={`user-${signUp.user.id}-cell--${field.field}`}>
                                     <CellContent signUp={signUp} field={field} />
                                   </TableCell>
                                 ))}
+                                {data.event.product && (
+                                  <TableCell>
+                                    {signUp.hasBoughtTicket ? <Check color="primary" /> : <Close color="error" />}
+                                  </TableCell>
+                                )}
                                 <TableCell>
                                   <Tooltip title="Fjern påmelding" arrow>
                                     {signOffLoading ? (
@@ -231,7 +235,7 @@ const EventAdminPage: NextPage = () => {
                 <Card variant="outlined">
                   <CardHeader title="Venteliste" />
                   <CardContent>
-                    {data?.event?.usersOnWaitingList?.length !== 0 ? (
+                    {data.event?.usersOnWaitingList?.length !== 0 ? (
                       <TableContainer style={{ maxHeight: 600 }}>
                         <Table>
                           <TableHead>
@@ -242,7 +246,7 @@ const EventAdminPage: NextPage = () => {
                             </TableRow>
                           </TableHead>
                           <TableBody>
-                            {data?.event?.usersOnWaitingList?.map((signUp: SignUp) => (
+                            {data.event?.usersOnWaitingList?.map((signUp: SignUp) => (
                               <TableRow key={`user-row-${signUp.user.id}`}>
                                 {signUpFields.map((field) => (
                                   <TableCell key={`user-${signUp.user.id}-cell--${field.field}`}>


### PR DESCRIPTION
## Proposed Changes

- Fix bug causing duplicate hasBoughtTicket columns

## Types of Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- When the event admin page re-renders, an additional column of icons indicating whether the user has bought a ticket is rendered

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
