### PR TITLE
Use allergies field from user FK in exports

### DIFF
--- a/backend/apps/events/resolvers.py
+++ b/backend/apps/events/resolvers.py
@@ -20,7 +20,7 @@ DEFAULT_REPORT_FIELDS = {
     "signup_user_grade_year",
     "signup_user_email",
     "signup_user_phone_number",
-    "signup_user_allergies",
+    "user_allergies",
 }
 
 FiletypeSpec = namedtuple("FiletypeSpec", ["content_type", "extension"])


### PR DESCRIPTION
## Proposed Changes

- Use the currently saved allergies field on user model when exporting event attendee reports

## Types of Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

-

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
