### PR TITLE
fix: make tz unaware for xslx export

### DIFF
--- a/backend/apps/events/resolvers.py
+++ b/backend/apps/events/resolvers.py
@@ -212,6 +212,8 @@ def wrap_attendee_report_as_json(df, file_basename, filetype):
     if filetype == "xlsx":
         if "signup_timestamp" in df:
             df["signup_timestamp"] = df["signup_timestamp"].apply(lambda a: pd.to_datetime(a).tz_localize(None))
+        if "order_timestamp" in df:
+            df["order_timestamp"] = df["order_timestamp"].apply(lambda a: pd.to_datetime(a).tz_localize(None))
         buffer = io.BytesIO()
         with pd.ExcelWriter(buffer, engine="xlsxwriter", options={"remove_timezone": True}) as writer:
             df.to_excel(writer, index=False)


### PR DESCRIPTION
## Proposed Changes

- Excel does not support TZ aware datetimes, remove it for `order_timestamp`.

## Types of Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- SENTRY5618268

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [ ] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
