### PR TITLE
fix: set cookie domain

### DIFF
--- a/backend/api/auth/middleware.py
+++ b/backend/api/auth/middleware.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.auth import get_user_model
+from django.conf import settings
 
 
 class IndokWebJWTMiddleware:
@@ -10,7 +11,13 @@ class IndokWebJWTMiddleware:
         response = self.get_response(request)
         jwt_token = getattr(request, "set_jwt_cookie", None)
         if jwt_token:
-            response.set_cookie("JWT", jwt_token, max_age=24 * 60 * 60, httponly=True)
+            response.set_cookie(
+                "JWT",
+                jwt_token,
+                max_age=24 * 60 * 60,
+                httponly=True,
+                domain=settings.GRAPHQL_JWT.get("JWT_COOKIE_DOMAIN", None),
+            )
 
         return response
 


### PR DESCRIPTION
## Proposed Changes

- We're using a custom JWT middleware, so the cookie's domain is set there.

## Types of Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- Cannot log out due to a mismatch between the cookie domain set on login and when logging out. I.e., `DeleteJSONWebTokenCookie` tries to delete a cookie with domain `indokntnu.no`, but our cookies have domain `api.indokntnu.no`

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [ ] I am pleased with the readability of the code (if not, state where you need input)
- [ ] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
