### PR TITLE
🎨 style: remove anniversary styling

### DIFF
--- a/frontend/src/components/Footer/index.tsx
+++ b/frontend/src/components/Footer/index.tsx
@@ -46,7 +46,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   nth: {
-    background: "url('/static/anniversary/anniversary_logo_black.svg')",
+    background: "url('/nth.svg')",
     backgroundSize: 500,
     backgroundPosition: "right center",
     backgroundRepeat: "no-repeat",

--- a/frontend/src/components/Title.tsx
+++ b/frontend/src/components/Title.tsx
@@ -1,19 +1,4 @@
-import { Box, Grid, Hidden, makeStyles, Typography, useTheme } from "@material-ui/core";
-
-const useStyles = makeStyles(() => ({
-  anniversary: {
-    transition: "0.7s all ease",
-    background: "url('/static/anniversary/anniversary_logo_black.svg')",
-    backgroundSize: "contain",
-    backgroundPosition: "right",
-    backgroundRepeat: "no-repeat",
-    opacity: 0.05,
-    height: "120%",
-    marginRight: "10%",
-    right: 0,
-    top: 0,
-  },
-}));
+import { Box, Grid, Typography, useTheme } from "@material-ui/core";
 
 type Props = {
   children: string;
@@ -21,7 +6,6 @@ type Props = {
 
 const Title: React.FC<Props> = ({ children }) => {
   const theme = useTheme();
-  const classes = useStyles();
 
   return (
     <Box
@@ -42,9 +26,6 @@ const Title: React.FC<Props> = ({ children }) => {
           </Grid>
         </Grid>
       </Grid>
-      <Hidden smDown>
-        <Box className={classes.anniversary} position="absolute" width="100vw" height="100vh" />
-      </Hidden>
     </Box>
   );
 };

--- a/frontend/src/components/landing/LandingHero.tsx
+++ b/frontend/src/components/landing/LandingHero.tsx
@@ -117,7 +117,7 @@ const useStyles = makeStyles((theme) => ({
   },
   nth: {
     transition: "0.7s all ease",
-    background: "url('/static/anniversary/anniversary_logo_black.svg')",
+    background: "url('/nth.svg')",
     backgroundSize: "contain",
     backgroundPosition: "left bottom!important",
     backgroundRepeat: "no-repeat",

--- a/frontend/src/components/navbar/Navbar.tsx
+++ b/frontend/src/components/navbar/Navbar.tsx
@@ -1,3 +1,6 @@
+import { useQuery } from "@apollo/client";
+import { GET_USER } from "@graphql/users/queries";
+import { User } from "@interfaces/users";
 import {
   AppBar,
   Box,
@@ -11,16 +14,10 @@ import {
   useScrollTrigger,
 } from "@material-ui/core";
 import MenuIcon from "@material-ui/icons/Menu";
-import leftFern from "@public/static/anniversary/left_fern.svg";
-import rightFern from "@public/static/anniversary/right_fern.svg";
-import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import React, { ReactElement, useState } from "react";
 import NavbarLinks from "./NavbarLinks";
-import { useQuery } from "@apollo/client";
-import { GET_USER } from "@graphql/users/queries";
-import { User } from "@interfaces/users";
 import NavbarUser from "./NavbarLinks/NavbarUser";
 
 //set navbar style breakpoint, should be adjusted according to width of NavbarLinks
@@ -32,7 +29,6 @@ const useStyles = makeStyles((theme) => ({
   },
   appBar: {
     background: theme.palette.primary.dark,
-    backgroundImage: "url('/static/anniversary/sparkles.gif')",
     backgroundPosition: "bottom",
   },
   toolbar: {
@@ -48,10 +44,10 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: "row",
   },
   titleLink: {
-    color: "#eec643", //b0aca5
+    color: "#b0aca5",
 
     "&:hover": {
-      color: "#ffd754",
+      color: "#fff",
     },
   },
   sectionDesktop: {
@@ -102,17 +98,11 @@ const Navbar: React.FC = () => {
           <Container className={classes.container}>
             <Toolbar className={classes.toolbar}>
               <Box className={classes.title}>
-                <Box height="auto" width={38} position="relative">
-                  <Image src={leftFern} layout="fill" alt="" />
-                </Box>
                 <Link href="/" passHref>
                   <Typography component="a" className={classes.titleLink} variant="h5">
                     INDØK
                   </Typography>
                 </Link>
-                <Box height="auto" width={38} position="relative">
-                  <Image src={rightFern} layout="fill" alt="" />
-                </Box>
               </Box>
               <div className={classes.sectionDesktop}>
                 <NavbarLinks loggedIn={loggedIn} />

--- a/frontend/src/pages/events/index.tsx
+++ b/frontend/src/pages/events/index.tsx
@@ -9,18 +9,6 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: theme.spacing(4),
     paddingBottom: theme.spacing(8),
   },
-  anniversary: {
-    transition: "0.7s all ease",
-    background: "url('/static/anniversary/anniversary_logo_black.svg')",
-    backgroundSize: "contain",
-    backgroundPosition: "right",
-    backgroundRepeat: "no-repeat",
-    opacity: 0.05,
-    height: "120%",
-    marginRight: "10%",
-    right: 0,
-    top: 0,
-  },
 }));
 
 /**
@@ -49,9 +37,6 @@ const Events: NextPage = () => {
             <Tab label="Kalender" />
           </Tabs>
         </Container>
-        <Hidden xsDown>
-          <Box className={classes.anniversary} position="absolute" width="100vw" height="100vh" />
-        </Hidden>
       </Box>
       <Container className={classes.container}>
         {showCalendarView ? (


### PR DESCRIPTION
## Proposed Changes

- Remove the custom anniversary styling as the anniversary draws to an end.

## To do

- [ ] Figure out what to do this component. Should it remain, but with updated content? Revert to the original design? Other suggestions? Personally, I really like it
![Screen Shot 2022-03-10 at 00 49 43](https://user-images.githubusercontent.com/46653859/157558889-6b8c40fa-7460-4dba-b3dc-83bab55dfa93.png)

## Types of Changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [x] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

-

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
