### PR TITLE
fix: cap header sizes at 3 for markdown

### DIFF
--- a/frontend/src/components/markdown/components.tsx
+++ b/frontend/src/components/markdown/components.tsx
@@ -2,7 +2,7 @@ import { Typography } from "@material-ui/core";
 import { Components } from "react-markdown";
 
 const Heading: Components["h1"] = ({ children, id, level }) => {
-  const variant = `h${Math.min(level, 3)}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  const variant = `h${Math.max(level, 3)}` as "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
   return (
     <Typography id={id} variant={variant} component={variant} gutterBottom>
       {children}


### PR DESCRIPTION
## Proposed Changes

- Fix my attempt at capping header sizes at 3 for markdown

## Types of Changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [x] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

-

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
