### PR TITLE
🔨 build: move stable swc features

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -30,10 +30,12 @@ const moduleExports = {
       },
     ];
   },
-  experimental: {
-    outputStandalone: true,
+  compiler: {
     styledComponents: true,
     ...getPresets(),
+  },
+  experimental: {
+    outputStandalone: true,
   },
   swcMinify: true,
   webpack: (config, { isServer }) => {


### PR DESCRIPTION
## Proposed Changes

- Move `styledComponents`, `reactRemoveProperties` and `removeConsole` to `compiler` as they are now [stable](https://nextjs.org/docs/advanced-features/compiler#supported-features).

## Types of Changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [x] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- Closes #

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [ ] I am pleased with the readability of the code (if not, state where you need input)
- [ ] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
