### PR TITLE
feat: permit cabin bookings globally

### DIFF
--- a/backend/apps/cabins/helpers.py
+++ b/backend/apps/cabins/helpers.py
@@ -1,7 +1,11 @@
 from datetime import date
+from typing import TYPE_CHECKING
 
 from django.db import models
 from django.db.models import QuerySet
+
+if TYPE_CHECKING:
+    from apps.cabins.models import Cabin
 
 """
 Helper method used in the app
@@ -17,7 +21,7 @@ def is_internal_price(internal_participants: int, external_participants: int) ->
 
 
 def price(
-    cabins: QuerySet, check_in: date, check_out: date, internal_participants: int, external_participants: int
+    cabins: QuerySet["Cabin"], check_in: date, check_out: date, internal_participants: int, external_participants: int
 ) -> int:
     if is_internal_price(internal_participants, external_participants):
         price_pr_night = cabins.aggregate(models.Sum("internal_price"))["internal_price__sum"]

--- a/backend/apps/cabins/migrations/0002_auto_20200928_1413.py
+++ b/backend/apps/cabins/migrations/0002_auto_20200928_1413.py
@@ -15,4 +15,4 @@ class Migration(migrations.Migration):
         ("cabins", "0001_initial"),
     ]
 
-    operations = [migrations.RunPython(create_cabins)]
+    operations = []

--- a/backend/apps/cabins/mutations.py
+++ b/backend/apps/cabins/mutations.py
@@ -1,13 +1,15 @@
 import graphene
-
-from .helpers import price
-from .types import AllBookingsType, BookingInfoType, EmailInputType, UpdateBookingSemesterType
-from apps.cabins.models import Booking as BookingModel, BookingSemester
-from apps.cabins.models import Cabin as CabinModel
-from .constants import APPROVE_BOOKING, DISAPPROVE_BOOKING
-from .mail import send_mail
-from .validators import create_booking_validation
 from graphql_jwt.decorators import permission_required
+
+from apps.cabins.models import Booking as BookingModel
+from apps.cabins.models import BookingSemester
+from apps.cabins.models import Cabin as CabinModel
+
+from .constants import APPROVE_BOOKING, DISAPPROVE_BOOKING
+from .helpers import price
+from .mail import send_mail
+from .types import AllBookingsType, BookingInfoType, EmailInputType, UpdateBookingSemesterType
+from .validators import create_booking_validation
 
 
 class BookingInput(graphene.InputObjectType):
@@ -58,7 +60,6 @@ class CreateBooking(graphene.Mutation):
     ok = graphene.Boolean()
     booking = graphene.Field(AllBookingsType)
 
-    @permission_required("cabins.add_booking")
     def mutate(
         self,
         info,
@@ -150,7 +151,6 @@ class SendEmail(graphene.Mutation):
 
     ok = graphene.Boolean()
 
-    @permission_required("cabins.send_email")
     def mutate(self, info, email_input: EmailInputType):
         cabins = CabinModel.objects.filter(id__in=email_input["cabins"])
 

--- a/backend/apps/cabins/tests.py
+++ b/backend/apps/cabins/tests.py
@@ -189,12 +189,6 @@ class CabinsMutationsTestCase(CabinsBaseTestCase):
         self.assertEqual(3, len(Booking.objects.all()))
 
     def test_create_booking(self):
-        # Test booking creation without add_booking permission
-        response = self.create_booking(self.no_conflict_booking, f"{self.bjornen_cabin.id}")
-        self.assert_permission_error(response)
-
-        # Test with add_booking permission
-        self.add_booking_permission("add_booking")
         response = self.create_booking(self.no_conflict_booking, f"{self.bjornen_cabin.id}", user=self.user)
         self.assertResponseNoErrors(response)
         # Check that booking is created
@@ -341,11 +335,6 @@ class EmailTestCase(CabinsBaseTestCase):
             }}
         """
         return self.query(query, user=user)
-
-    def test_mail_permission(self):
-        # Tries to send a mail with missing permissions
-        response = self.send_email(self.first_booking, "reserve_booking", user=self.user)
-        self.assert_permission_error(response)
 
     def test_outbox_size_reservation(self):
         # Check outbox size when sending reservation mails to both admin and user

--- a/backend/apps/cabins/tests.py
+++ b/backend/apps/cabins/tests.py
@@ -2,7 +2,7 @@ import json
 
 from django.core import mail
 
-from apps.cabins.models import Booking, Cabin, BookingResponsible
+from apps.cabins.models import Booking, BookingResponsible
 from apps.cabins.models import BookingSemester
 from apps.cabins.helpers import snake_case_to_camel_case
 from utils.testing.base import ExtendedGraphQLTestCase
@@ -10,6 +10,7 @@ from utils.testing.cabins_factories import BookingFactory
 import datetime
 
 from django.utils import timezone
+from utils.testing.factories.cabins import CabinFactory
 
 from utils.testing.factories.users import UserFactory
 from django.contrib.auth.models import Permission
@@ -21,8 +22,8 @@ class CabinsBaseTestCase(ExtendedGraphQLTestCase):
         super().setUp()
         # Create three bookings
         self.now = timezone.now()
-        self.bjornen_cabin = Cabin.objects.get(name="Bjørnen")
-        self.oksen_cabin = Cabin.objects.get(name="Oksen")
+        self.bjornen_cabin = CabinFactory(name="Bjørnen")
+        self.oksen_cabin = CabinFactory(name="Oksen")
         self.first_booking = BookingFactory(
             check_in=self.now,
             check_out=self.now + datetime.timedelta(days=4),
@@ -323,7 +324,7 @@ class EmailTestCase(CabinsBaseTestCase):
                   phone: \"{booking.phone}\",
                   internalParticipants: {booking.internal_participants},
                   externalParticipants: {booking.external_participants},
-                  cabins: [1],
+                  cabins: [{self.oksen_cabin.id}],
                   checkIn: \"{booking.check_in.strftime(self.date_fmt)}\",
                   checkOut: \"{booking.check_out.strftime(self.date_fmt)}\",
                   emailType: \"{email_type}\",

--- a/backend/apps/cabins/validators.py
+++ b/backend/apps/cabins/validators.py
@@ -75,7 +75,7 @@ def checkin_validation(check_in, check_out, cabin_ids):
 
 
 def email_validation(email: str):
-    if not email.count("@") == 1 and "." not in email.split("@")[-1]:
+    if email.count("@") != 1 or "." not in email.split("@")[-1]:
         raise GraphQLError(f"Input email {email} is invalid")
 
 

--- a/backend/utils/testing/factories/cabins.py
+++ b/backend/utils/testing/factories/cabins.py
@@ -1,0 +1,11 @@
+from factory.django import DjangoModelFactory
+from apps.cabins import models
+
+
+class CabinFactory(DjangoModelFactory):
+    class Meta:
+        model = models.Cabin
+
+    max_guests = 18
+    internal_price = 1100
+    external_price = 2700

--- a/frontend/src/components/pages/cabins/Hero.tsx
+++ b/frontend/src/components/pages/cabins/Hero.tsx
@@ -1,9 +1,8 @@
-import PermissionRequired from "@components/permissions/PermissionRequired";
 import { Box, Button, Grid, makeStyles, Theme, Typography } from "@material-ui/core";
-import React from "react";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
 import NavigateNextIcon from "@material-ui/icons/NavigateNext";
 import Link from "next/link";
+import React from "react";
 
 const useStyles = makeStyles((theme: Theme) => ({
   hero: {
@@ -31,11 +30,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-interface Props {
-  isLoggedIn: boolean;
-}
-
-const Hero: React.VFC<Props> = ({ isLoggedIn }) => {
+const Hero: React.VFC = () => {
   const classes = useStyles();
 
   return (
@@ -46,24 +41,11 @@ const Hero: React.VFC<Props> = ({ isLoggedIn }) => {
         </Box>
       </Grid>
       <Grid xs={12} sm={6} item container justifyContent="center" zeroMinWidth>
-        <PermissionRequired
-          permission="cabins.add_booking"
-          fallback={
-            !isLoggedIn ? (
-              // User is not logged in, and therefore does not have the permission.
-              <Typography variant="h5">Du må være logget inn for å booke en hytte.</Typography>
-            ) : (
-              // User is logged in, but does not have the permission (we disabled cabin booking for a subset of the users)
-              <Typography variant="h5">Her blir det snart mulig å reservere indøkhyttene</Typography>
-            )
-          }
-        >
-          <Link href="/cabins/book" passHref>
-            <Button variant="contained" endIcon={<NavigateNextIcon />}>
-              Book nå
-            </Button>
-          </Link>
-        </PermissionRequired>
+        <Link href="/cabins/book" passHref>
+          <Button variant="contained" endIcon={<NavigateNextIcon />}>
+            Book nå
+          </Button>
+        </Link>
       </Grid>
       <Grid xs={12} sm={6} item container justifyContent="center">
         <Button

--- a/frontend/src/pages/cabins/index.tsx
+++ b/frontend/src/pages/cabins/index.tsx
@@ -1,31 +1,19 @@
-import { Typography, Box, Grid, Paper, Divider, Container } from "@material-ui/core";
-import { NextPage } from "next";
-import Link from "next/link";
-import React, { useEffect, useState } from "react";
-import ImageSlider from "@components/pages/cabins/ImageSlider/ImageSlider";
-import { cabinImages, outsideImages } from "@components/pages/cabins/ImageSlider/imageData";
-import FAQ from "@components/pages/cabins/Documents/FAQ";
 import Layout from "@components/Layout";
-import { useQuery } from "@apollo/client";
-import { GET_USER } from "@graphql/users/queries";
-import { User } from "@interfaces/users";
-import Image from "next/image";
 import ContactCabinBoard from "@components/pages/cabins/ContactCabinBoard";
+import FAQ from "@components/pages/cabins/Documents/FAQ";
 import Hero from "@components/pages/cabins/Hero";
+import { cabinImages, outsideImages } from "@components/pages/cabins/ImageSlider/imageData";
+import ImageSlider from "@components/pages/cabins/ImageSlider/ImageSlider";
+import { Box, Container, Divider, Grid, Paper, Typography } from "@material-ui/core";
+import { NextPage } from "next";
+import Image from "next/image";
+import Link from "next/link";
+import React from "react";
 
 /*
 Front page for cabins. Includes info about the cabins and link to the booking page (cabins/book).
 */
 const CabinsPage: NextPage = () => {
-  const { data, error } = useQuery<{ user: User }>(GET_USER);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-
-  useEffect(() => {
-    if (data && data.user && !error) {
-      setIsLoggedIn(true);
-    }
-  }, [data, error]);
-
   const facilitiesData = [
     {
       icon: <Image alt="" src="/img/undraw_home.svg" width={100} height={100} />,
@@ -93,7 +81,7 @@ const CabinsPage: NextPage = () => {
 
   return (
     <Layout>
-      <Hero isLoggedIn={isLoggedIn} />
+      <Hero />
       <Container>
         <Box my={5} id="anchorBox">
           <Paper>


### PR DESCRIPTION
# #594 SHOULD BE MERGED PRIOR TO THIS
## Proposed Changes

- Remove `permission_required` decorators for users to permit bookings without being logged in.
- Remove tests related to requiring permissions for bookings
- Fix minor existing bug in email validation
- Clean up some test cases, add cabin factory
  - Side note on why this is necessary: Previously, cabins were created using a migration, however, when running `apps.get_model` in a migration, you get the model at the state at which it had at the time of the migration. For cabins, this included `max_guests = 20`, causing tests with 40 participants to incorrectly pass, as the current default is 18.

## Types of Changes

- [x] New feature
- [x] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- Closes #449 

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
