### PR TITLE
fix: allow sending mail without postmark template

### DIFF
--- a/backend/utils/mail/streams.py
+++ b/backend/utils/mail/streams.py
@@ -131,13 +131,16 @@ class PostmarkEmail(EmailMultiAlternatives):
             "contact_mail": settings.CONTACT_EMAIL,
         }
         self.esp_extra: EspExtra = {"MessageStream": stream}
-        self.template_id = template_id
+        if template_id is not None:
+            # If these variables are set, anymail will attempt to utilize Postmark's template system
+            # raising a 422 error as the template ID is not found.
+            self.template_id = template_id
+            self.merge_global_data = (
+                default_template_variables | global_template_variables
+                if global_template_variables is not None
+                else default_template_variables
+            )
         self.merge_data = template_variables
-        self.merge_global_data = (
-            default_template_variables | global_template_variables
-            if global_template_variables is not None
-            else default_template_variables
-        )
 
         super().__init__(
             subject, body, from_email, to, bcc, connection, attachments, headers, alternatives, cc, reply_to


### PR DESCRIPTION
## Proposed Changes

- Avoid setting `template_id` and `global_merge_data` if `template_id` is `None`, as it raises an API error from Postmark due to Anymail attempting to use the Postmark Template API. See [postmark.py#L164](https://github.com/anymail/django-anymail/blob/c7288b9b725db0ff1ad3cb1312bedc523b0cdea7/anymail/backends/postmark.py#L164)

## Types of Changes

- [ ] New feature
- [X] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- Closes #593 

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
