### PR TITLE
Fix typo on cabins front page

### DIFF
--- a/frontend/src/components/pages/cabins/CabinPrices/index.tsx
+++ b/frontend/src/components/pages/cabins/CabinPrices/index.tsx
@@ -16,7 +16,7 @@ const CabinPrices: React.VFC = () => {
         <Typography variant="h3">Priser</Typography>
         <Divider component="br" />
         <Typography variant="body2">
-          Dersom dere er flere enn 50% eksterne (ikke indøk), må dere betale eksternpris. Indøkere betaler interpris.
+          Dersom dere er flere enn 50% eksterne (ikke indøk), må dere betale eksternpris. Indøkere betaler internpris.
           Merk at prisene kan variere med sesongene.
         </Typography>
       </Grid>


### PR DESCRIPTION
## Proposed Changes

- Fixed a typo on the cabins front page: interpris -> internpris.

## Types of Changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- 

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
