### PR TITLE
✨ feat: migration health check

### DIFF
--- a/backend/config/urls/base.py
+++ b/backend/config/urls/base.py
@@ -21,10 +21,13 @@ from django.urls import path
 from django.urls.conf import include
 from django.views.decorators.csrf import csrf_exempt
 
+from config.views.health import health_check
+
 urlpatterns = [
     path(settings.ADMIN_URL, admin.site.urls),
     path("ping", Ping.as_view()),
     path("-/", include("django_alive.urls")),
     path("ecommerce/", include("apps.ecommerce.urls")),
     path("csrf/", csrf_exempt(csrf.csrf)),
+    path("health/", health_check),
 ]

--- a/backend/config/views/health.py
+++ b/backend/config/views/health.py
@@ -1,0 +1,20 @@
+from django.db import DEFAULT_DB_ALIAS, connections
+from django.db.migrations.executor import MigrationExecutor
+from django.http import HttpResponse, HttpRequest
+
+
+def health_check(_: HttpRequest):
+    """
+    Service is healthy if DB is migrated to the current state,
+    otherwise it is not. This is used in combination with AWS ELB health
+    checks in order to run DB migrations only when necessary.
+
+    Returns
+    -------
+    HttpResponse
+        200 if all good, 503 if there are migrations pending.
+    """
+    executor = MigrationExecutor(connections[DEFAULT_DB_ALIAS])
+    plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
+    status = 503 if plan else 200
+    return HttpResponse(status=status)


### PR DESCRIPTION
## Proposed Changes

- Add health check that fails if the DB is not migrated, in preparation for moving the migration step out of the entrypoint in order to reduce the time for a new instance to start when scaling up AWS.
- The general idea is:
  - Deploy, no worries, container spins up and ELB starts with health checks, which will fail initially. Great, people are still using the stable, previous, release. Simultaneously, a migration task has started and is migrating the DB. As soon as it completes, the health check passes and ELB starts routing requests to the new deployment.

## Types of Changes

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [x] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- Closes #

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
