### PR TITLE
🔨 build: public and smaller base images, minor fixes

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,8 +1,12 @@
 # pull official base image
-FROM --platform=linux/amd64 python:3.9.6
+FROM --platform=linux/amd64 public.ecr.aws/docker/library/python:3.9-slim
 
 # set work directory
 WORKDIR /usr/src/app
+RUN apt-get update && \
+    apt-get install -y \
+    libpango-1.0-0 \
+    libpangoft2-1.0-0
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,8 @@ FROM --platform=linux/amd64 public.ecr.aws/docker/library/python:3.9-slim
 
 # set work directory
 WORKDIR /usr/src/app
+
+# install weasyprint dependencies
 RUN apt-get update && \
     apt-get install -y \
     libpango-1.0-0 \

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -29,6 +29,7 @@ RUN pip wheel --no-cache-dir --no-deps --wheel-dir /usr/src/app/wheels -r ./requ
 FROM public.ecr.aws/docker/library/python:3.9-slim as runner
 WORKDIR /usr/src/app
 
+# install weasyprint dependencies
 RUN apt-get update && \
     apt-get install -y \
     libpango-1.0-0 \

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -3,7 +3,7 @@
 ###########
 
 # pull official base image
-FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/python:3.9 as builder
+FROM public.ecr.aws/docker/library/python:3.9-slim as builder
 
 # set work directory
 WORKDIR /usr/src/app
@@ -26,8 +26,13 @@ RUN pip wheel --no-cache-dir --no-deps --wheel-dir /usr/src/app/wheels -r ./requ
 ##########
 
 # pull official base image
-FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/python:3.9 as runner
+FROM public.ecr.aws/docker/library/python:3.9-slim as runner
 WORKDIR /usr/src/app
+
+RUN apt-get update && \
+    apt-get install -y \
+    libpango-1.0-0 \
+    libpangoft2-1.0-0
 
 # create directory for the app user
 RUN addgroup --gid 1001 -system python

--- a/backend/apps/archive/fixtures/initial_data.yaml
+++ b/backend/apps/archive/fixtures/initial_data.yaml
@@ -1,1 +1,18 @@
-[]
+- model: archive.ArchiveDocument
+  pk: 1
+  fields:
+    title: Protokoll Generalforsamling H21
+    type_doc: Generalforsamling
+    file_location: 1Z6VaWoGozMg560zjj0bGjQNkIYPOOn-u
+    featured: true
+    year: 2021
+    web_link: https://drive.google.com/file/d/1Z6VaWoGozMg560zjj0bGjQNkIYPOOn-u/view?usp=drivesdk
+- model: archive.ArchiveDocument
+  pk: 2
+  fields:
+    title: Budsjett Foreningen V22
+    type_doc: Budsjett og Regnskap
+    file_location: 1Ob5xYDvsv4CKfgPn0saAUAsXFVwGo4OON8kuPgcBNtA
+    featured: false
+    year: 2022
+    web_link: https://docs.google.com/spreadsheets/d/1Ob5xYDvsv4CKfgPn0saAUAsXFVwGo4OON8kuPgcBNtA/edit?usp=drivesdk

--- a/backend/apps/archive/google_drive_api.py
+++ b/backend/apps/archive/google_drive_api.py
@@ -1,19 +1,16 @@
-from __future__ import print_function
+from typing import Optional
 
 from django.conf import settings
 from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
 
 
-# Connect to the Drive v3 API
-service = build("drive", "v3", developerKey=settings.GOOGLE_DRIVE_API_KEY)
+class GoogleDriveAPI:
+    def __init__(self):
+        self.service = build("drive", "v3", developerKey=settings.GOOGLE_DRIVE_API_KEY)
 
-
-def get_url(file_id):
-    # Call the Drive v3 API
-    try:
+    def get_url(self, file_id: str) -> Optional[str]:
         file = (
-            service.files()
+            self.service.files()
             .get(
                 fileId=file_id,
                 fields="id, name, webViewLink",
@@ -21,16 +18,16 @@ def get_url(file_id):
             )
             .execute()
         )
+        return file["webViewLink"]
 
-    except HttpError as err:
-        print(err)
-        print("No files found.")
-        return None
-
-    return file["webViewLink"]
-
-
-def get_thumbnail(file_id):
-    # No need to call the Drive v3 API
-    thumbnail_link = "https://drive.google.com/thumbnail?id=" + file_id
-    return thumbnail_link
+    def get_thumbnail(self, file_id: str) -> Optional[str]:
+        file = (
+            self.service.files()
+            .get(
+                fileId=file_id,
+                fields="id, name, thumbnailLink",
+                supportsTeamDrives=True,
+            )
+            .execute()
+        )
+        return file["thumbnailLink"]

--- a/backend/apps/archive/models.py
+++ b/backend/apps/archive/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from datetime import datetime
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from .google_drive_api import get_url
+from .google_drive_api import GoogleDriveAPI
 from django.core.exceptions import FieldError
 
 
@@ -40,7 +40,8 @@ class ArchiveDocument(models.Model):
 @receiver(post_save, sender=ArchiveDocument)
 def notify_doc(sender, instance, created, **kwargs):
     if created:
-        instance.web_link = get_url(instance.file_location)
+        drive = GoogleDriveAPI()
+        instance.web_link = drive.get_url(instance.file_location)
         if instance.web_link is None:
             instance.delete()
             raise FieldError(

--- a/backend/apps/archive/types.py
+++ b/backend/apps/archive/types.py
@@ -1,7 +1,7 @@
 import graphene
 from graphene_django import DjangoObjectType
 
-from .google_drive_api import get_thumbnail
+from .google_drive_api import GoogleDriveAPI
 from .models import ArchiveDocument
 
 
@@ -13,4 +13,5 @@ class ArchiveDocumentType(DjangoObjectType):
 
     @staticmethod
     def resolve_thumbnail(root: ArchiveDocument, info):
-        return get_thumbnail(root.file_location)
+        drive = GoogleDriveAPI()
+        return drive.get_thumbnail(root.file_location)

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Larger base image for development
-FROM --platform=linux/amd64 node:16.13.2
+FROM --platform=linux/amd64 public.ecr.aws/docker/library/node:lts-alpine3.16
 
 WORKDIR /app
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -2,7 +2,7 @@
 ARG APP_ENV=production
 
 # Install dependencies only when needed
-FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/node:16.13.2-alpine AS deps
+FROM public.ecr.aws/docker/library/node:lts-alpine3.16 AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /usr/src/app
@@ -10,7 +10,7 @@ COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 # Rebuild the source code only when needed
-FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/node:16.13.2-alpine AS builder
+FROM public.ecr.aws/docker/library/node:lts-alpine3.16 AS builder
 WORKDIR /usr/src/app
 COPY --from=deps /usr/src/app/node_modules ./node_modules
 COPY . .
@@ -28,7 +28,7 @@ COPY .env.${APP_ENV} .env.production
 RUN yarn build 
 
 # Production image, copy all the files and run next
-FROM 777854691961.dkr.ecr.eu-north-1.amazonaws.com/node:16.13.2-alpine AS runner
+FROM public.ecr.aws/docker/library/node:lts-alpine3.16 AS runner
 WORKDIR /usr/src/app
 
 RUN addgroup -g 1001 -S nodejs


### PR DESCRIPTION
## Proposed Changes

- Move to public base images for Node and Python
  - More frequent security updates, no need for authentication. 5 TB of data transfer as an authorized user.
- Use slim Python base image
  - Add dependencies for Weasyprint
- Move Google Drive API away from top level to keep it from breaking the app if the secret key is not set.

## Types of Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [x] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- Closes #

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [ ] I am pleased with the readability of the code (if not, state where you need input)
- [ ] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
