### PR TITLE
ci: run cypress in chrome to avoid frozen playback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,6 @@ jobs:
     needs: [prepare, build]
     name: E2E Tests
     runs-on: ubuntu-latest
-    container: cypress/browsers:node16.13.2-chrome100-ff98
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
     needs: [prepare, build]
     name: E2E Tests
     runs-on: ubuntu-latest
+    container: cypress/browsers:node16.13.2-chrome100-ff98
     strategy:
       fail-fast: false
       matrix:
@@ -232,6 +233,7 @@ jobs:
           group: "E2E"
           working-directory: e2e
           headless: true
+          browser: chrome
           ci-build-id: ${{ needs.prepare.outputs.uuid }}
           wait-on: "http://localhost:8000/-/health, http://localhost:3000/api/health"
         env:


### PR DESCRIPTION
## Proposed Changes

- For some reason, playback freezes in Electron, but works fine in Chrome.

## Types of Changes

- [ ] New feature
- [ ] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [ ] Style
- [ ] Build/dependencies
- [x] Other

## Issue(s) fixed or closed by this PR

- Closes #

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [ ] I am pleased with the readability of the code (if not, state where you need input)
- [ ] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
