### PR TITLE
refactor(listings): form admin UI

### DIFF
--- a/frontend/src/components/pages/forms/AnswerForm.tsx
+++ b/frontend/src/components/pages/forms/AnswerForm.tsx
@@ -61,31 +61,34 @@ const AnswerForm: React.FC<{
           </CardContent>
         </Card>
       </Grid>
-      {Object.entries(questions).map(([id, { question, answer }]) => (
-        <Grid item key={id}>
-          <Card>
-            <CardContent>
-              <Grid container direction="column">
-                <Grid item>
-                  <Typography>
-                    {question.question}
-                    {question.mandatory && " *"}
-                  </Typography>
+      {Object.entries(questions)
+        // sorts questions by ID (hacky solution to maintain question order until we implement order field)
+        .sort(([id1], [id2]) => (parseInt(id1) || 0) - (parseInt(id2) || 0))
+        .map(([id, { question, answer }]) => (
+          <Grid item key={id}>
+            <Card>
+              <CardContent>
+                <Grid container direction="column">
+                  <Grid item>
+                    <Typography>
+                      {question.question}
+                      {question.mandatory && " *"}
+                    </Typography>
+                  </Grid>
+                  <Grid item>
+                    <AnswerQuestion
+                      question={question}
+                      answer={answer}
+                      onValueChanged={(value) =>
+                        setQuestions((prevState) => ({ ...prevState, [id]: { ...prevState[id], answer: value } }))
+                      }
+                    />
+                  </Grid>
                 </Grid>
-                <Grid item>
-                  <AnswerQuestion
-                    question={question}
-                    answer={answer}
-                    onValueChanged={(value) =>
-                      setQuestions((prevState) => ({ ...prevState, [id]: { ...prevState[id], answer: value } }))
-                    }
-                  />
-                </Grid>
-              </Grid>
-            </CardContent>
-          </Card>
-        </Grid>
-      ))}
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
       {errorMessage && (
         <Grid item>
           <Card>

--- a/frontend/src/components/pages/forms/formAdmin/EditForm.tsx
+++ b/frontend/src/components/pages/forms/formAdmin/EditForm.tsx
@@ -198,24 +198,27 @@ const EditForm: React.FC<{ form: Form }> = ({ form }) => {
             </CardContent>
           </Card>
         </Grid>
-        {form.questions.map((question) => (
-          <Grid item key={question.id}>
-            <Card>
-              <CardContent>
-                {question.id === activeQuestion?.id ? (
-                  <EditQuestion
-                    question={activeQuestion}
-                    setQuestion={(question) => setActiveQuestion(question)}
-                    saveQuestion={() => switchActiveQuestion(undefined)}
-                    deleteQuestion={deleteActiveQuestion}
-                  />
-                ) : (
-                  <QuestionPreview question={question} setActive={() => switchActiveQuestion(question)} />
-                )}
-              </CardContent>
-            </Card>
-          </Grid>
-        ))}
+        {form.questions
+          // sorts questions by ID (hacky solution to maintain question order until we implement order field)
+          .sort((q1, q2) => (parseInt(q1.id) || 0) - (parseInt(q2.id) || 0))
+          .map((question) => (
+            <Grid item key={question.id}>
+              <Card>
+                <CardContent>
+                  {question.id === activeQuestion?.id ? (
+                    <EditQuestion
+                      question={activeQuestion}
+                      setQuestion={(question) => setActiveQuestion(question)}
+                      saveQuestion={() => switchActiveQuestion(undefined)}
+                      deleteQuestion={deleteActiveQuestion}
+                    />
+                  ) : (
+                    <QuestionPreview question={question} setActive={() => switchActiveQuestion(question)} />
+                  )}
+                </CardContent>
+              </Card>
+            </Grid>
+          ))}
         <Grid item>
           <Button
             fullWidth

--- a/frontend/src/components/pages/forms/formAdmin/FormResponse.tsx
+++ b/frontend/src/components/pages/forms/formAdmin/FormResponse.tsx
@@ -41,18 +41,21 @@ const FormResponse: React.FC<{
       </Grid>
       <Grid item>
         <Grid container direction="column" spacing={1}>
-          {form.questions.map((question) => (
-            <Grid item key={question.id}>
-              <Card>
-                <CardContent>
-                  <FormAnswer
-                    question={question}
-                    answer={response.answers.find((answer) => answer.question?.id === question.id)}
-                  />
-                </CardContent>
-              </Card>
-            </Grid>
-          ))}
+          {form.questions
+            // sorts questions by ID (hacky solution to maintain question order until we implement order field)
+            .sort((q1, q2) => (parseInt(q1.id) || 0) - (parseInt(q2.id) || 0))
+            .map((question) => (
+              <Grid item key={question.id}>
+                <Card>
+                  <CardContent>
+                    <FormAnswer
+                      question={question}
+                      answer={response.answers.find((answer) => answer.question?.id === question.id)}
+                    />
+                  </CardContent>
+                </Card>
+              </Grid>
+            ))}
         </Grid>
       </Grid>
     </Grid>

--- a/frontend/src/components/pages/listings/organization/OrganizationListings.tsx
+++ b/frontend/src/components/pages/listings/organization/OrganizationListings.tsx
@@ -60,12 +60,7 @@ const OrganizationListings: React.FC<{
                       <Stack spacing={1} direction="row" justifyContent="flex-end">
                         <Link href={`${organization.id}/listings/${listing.id}`} passHref>
                           <Button variant="contained" color="secondary" startIcon={<Create />}>
-                            Rediger søknad
-                          </Button>
-                        </Link>
-                        <Link passHref href={`${organization.id}/listings/${listing.id}/edit/`}>
-                          <Button variant="contained" color="secondary" startIcon={<Create />}>
-                            Rediger
+                            Administrer
                           </Button>
                         </Link>
                         <Button


### PR DESCRIPTION
### Changes

- sort form questions by id as a temporary solution to keep order consistent
- change confusing/redundant buttons in listing admin page

Long-term, we should implement a proper `order` field on questions, but for now, sorting by ID works, as we do not support changing order of questions. We _sort of_ do this already when answering forms, as we convert questions to an object and then back to an array, which sorts the resulting array by key (ID in this case). This makes this behavior consistent for the admin pages as well.