### PR TITLE
:art: style: update listings, fix og:image

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -58,6 +58,13 @@ const moduleExports = {
         transform: "lodash/{{member}}",
       },
     },
+
+    images: {
+      allowFutureImage: true,
+    },
+  },
+  images: {
+    domains: ["indokweb-assets.s3.eu-north-1.amazonaws.com"],
   },
   webpack: (config, { isServer }) => {
     // In `pages/_app.js`, Sentry is imported from @sentry/browser. While

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -65,6 +65,7 @@
     "@graphql-codegen/typescript-operations": "2.5.2",
     "@graphql-codegen/typescript-react-apollo": "3.3.2",
     "@graphql-codegen/typescript-resolvers": "2.7.2",
+    "@graphql-typed-document-node/core": "^3.1.1",
     "@types/cookie": "^0.5.1",
     "@types/node": "^16.11.22",
     "@types/react": "^17.0.11",

--- a/frontend/src/components/Title/variants/BaseTitle.tsx
+++ b/frontend/src/components/Title/variants/BaseTitle.tsx
@@ -9,9 +9,9 @@ import { ImageContainer, ImageOverlay, OverlayProps, RootStyle } from "./styles"
 const Image = dynamic(() => import("next/image"));
 
 export type Props = {
-  title: string;
+  title?: string;
   overline?: string;
-  breadcrumbs: TLink[];
+  breadcrumbs?: TLink[];
   sx?: SxProps<Theme>;
   BreadcrumbProps?: Partial<BreadcrumbProps>;
   bgImage?: StaticImageData | string;
@@ -23,7 +23,7 @@ export type Props = {
 const Title: React.FC<Props> = ({
   title,
   children,
-  breadcrumbs,
+  breadcrumbs = [],
   overline,
   sx,
   bgImage,

--- a/frontend/src/components/Title/variants/BaseTitle.tsx
+++ b/frontend/src/components/Title/variants/BaseTitle.tsx
@@ -16,7 +16,7 @@ export type Props = {
   BreadcrumbProps?: Partial<BreadcrumbProps>;
   bgImage?: StaticImageData | string;
   disableGutters?: boolean;
-  ImageProps?: ImageProps;
+  ImageProps?: Partial<ImageProps>;
   OverlayProps?: OverlayProps & { sx?: SxProps<Theme> };
 };
 

--- a/frontend/src/components/Title/variants/styles.ts
+++ b/frontend/src/components/Title/variants/styles.ts
@@ -24,6 +24,7 @@ export const ImageContainer = styled(Box)(({ theme }) => ({
   position: "absolute",
   overflow: "hidden",
   height: "100%",
+  width: "100%",
   "& span": { height: "100% !important" },
   marginTop: `-${HEADER_MOBILE_HEIGHT}px`,
   [theme.breakpoints.up("md")]: {

--- a/frontend/src/components/pages/listings/detail/TitleCard.tsx
+++ b/frontend/src/components/pages/listings/detail/TitleCard.tsx
@@ -1,10 +1,12 @@
-import { ListingQuery } from "@generated/graphql";
+import { ListingDocument, ListingQuery } from "@generated/graphql";
+import { ResultOf } from "@graphql-typed-document-node/core";
 import { ArrowForward } from "@mui/icons-material";
-import { Button, Card, CardContent, Grid, Hidden, Typography } from "@mui/material";
+import { Box, Button, Card, CardContent, Stack, Typography } from "@mui/material";
 import dayjs from "dayjs";
 import nb from "dayjs/locale/nb";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
+import Image from "next/future/image";
 import Link from "next/link";
 dayjs.extend(timezone);
 dayjs.extend(utc);
@@ -18,7 +20,7 @@ dayjs.locale(nb);
  * - the listing to render
  */
 const TitleCard: React.FC<{
-  listing: NonNullable<ListingQuery["listing"]>;
+  listing: NonNullable<ResultOf<typeof ListingDocument>["listing"]>;
 }> = ({ listing }) => {
   let link: string | undefined = undefined;
   if (listing.form) {
@@ -30,43 +32,37 @@ const TitleCard: React.FC<{
   }
 
   return (
-    <Card style={{ height: "100%" }}>
+    <Card>
       <CardContent>
-        <Grid container direction="column" justifyContent="space-between" alignItems="center">
-          <Grid item>
-            <Typography variant="h3" component="h1" align="center">
-              {listing.title}
+        <Stack direction={{ xs: "row", sm: "column" }} spacing={4} justifyContent="center" alignItems="center">
+          {listing.organization.logoUrl && (
+            <Box position="relative" width="100%" height={{ xs: "100px", sm: "150px" }}>
+              <Image
+                src={listing.organization.logoUrl}
+                unoptimized
+                fill
+                style={{ objectFit: "contain", objectPosition: "center", aspectRatio: "1" }}
+              />
+            </Box>
+          )}
+          <Stack direction="column" justifyContent="center" alignItems="center">
+            <Typography variant="h4" component="h4" align="center" gutterBottom>
+              {listing.organization.name}
             </Typography>
-          </Grid>
-          <Grid item>
-            <Typography
-              variant="caption"
-              component="h3"
-              align="center"
-              sx={{
-                "&::before": {
-                  content: "'Frist '",
-                  fontWeight: "bold",
-                  color: (theme) => theme.palette.primary.main,
-                },
-              }}
-              gutterBottom
-            >
-              {dayjs(listing.deadline).format("DD. MMMM YYYY [kl.] HH:mm")}
+            <Typography variant="caption" component="h3" align="center" gutterBottom>
+              {`Frist ${dayjs(listing.deadline).format("DD. MMMM YYYY [kl.] HH:mm")}`}
             </Typography>
-          </Grid>
-          <Hidden smDown>
-            <Grid item>
-              {link && (
+            {link && (
+              <Box>
                 <Link href={link} passHref>
                   <Button variant="contained" color="primary" endIcon={<ArrowForward />}>
                     Søk her
                   </Button>
                 </Link>
-              )}
-            </Grid>
-          </Hidden>
-        </Grid>
+              </Box>
+            )}
+          </Stack>
+        </Stack>
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/pages/listings/detail/TitleCard.tsx
+++ b/frontend/src/components/pages/listings/detail/TitleCard.tsx
@@ -1,4 +1,4 @@
-import { ListingDocument, ListingQuery } from "@generated/graphql";
+import { ListingDocument } from "@generated/graphql";
 import { ResultOf } from "@graphql-typed-document-node/core";
 import { ArrowForward } from "@mui/icons-material";
 import { Box, Button, Card, CardContent, Stack, Typography } from "@mui/material";

--- a/frontend/src/components/pages/listings/detail/TitleCard.tsx
+++ b/frontend/src/components/pages/listings/detail/TitleCard.tsx
@@ -1,13 +1,14 @@
 import { ListingDocument } from "@generated/graphql";
 import { ResultOf } from "@graphql-typed-document-node/core";
 import { ArrowForward } from "@mui/icons-material";
-import { Box, Button, Card, CardContent, Stack, Typography } from "@mui/material";
+import { Box, Button, Card, CardContent, Divider, Grid, Typography, Link as MuiLink } from "@mui/material";
 import dayjs from "dayjs";
 import nb from "dayjs/locale/nb";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import Image from "next/future/image";
 import Link from "next/link";
+import React from "react";
 dayjs.extend(timezone);
 dayjs.extend(utc);
 dayjs.tz.setDefault("Europe/Oslo");
@@ -20,10 +21,10 @@ dayjs.locale(nb);
  * - the listing to render
  */
 const TitleCard: React.FC<{
-  listing: NonNullable<ResultOf<typeof ListingDocument>["listing"]>;
+  listing: ResultOf<typeof ListingDocument>["listing"];
 }> = ({ listing }) => {
   let link: string | undefined = undefined;
-  if (listing.form) {
+  if (listing?.form) {
     link = `/forms/${listing.form.id}/`;
   } else if (listing?.applicationUrl) {
     link = listing.applicationUrl;
@@ -34,35 +35,48 @@ const TitleCard: React.FC<{
   return (
     <Card>
       <CardContent>
-        <Stack direction={{ xs: "row", sm: "column" }} spacing={4} justifyContent="center" alignItems="center">
-          {listing.organization.logoUrl && (
-            <Box position="relative" width="100%" height={{ xs: "100px", sm: "150px" }}>
-              <Image
-                src={listing.organization.logoUrl}
-                unoptimized
-                fill
-                style={{ objectFit: "contain", objectPosition: "center", aspectRatio: "1" }}
-              />
-            </Box>
+        <Grid container direction={{ xs: "row", sm: "column" }} spacing={4} justifyContent="center" alignItems="center">
+          {listing?.organization.logoUrl && (
+            <Grid container item xs={4} sm={12}>
+              <Box position="relative" height="150px" width="100%">
+                <Image
+                  src={listing?.organization.logoUrl}
+                  unoptimized
+                  fill
+                  style={{ objectFit: "contain", objectPosition: "center", aspectRatio: "1" }}
+                />
+              </Box>
+            </Grid>
           )}
-          <Stack direction="column" justifyContent="center" alignItems="center">
-            <Typography variant="h4" component="h4" align="center" gutterBottom>
-              {listing.organization.name}
-            </Typography>
+          <Grid container xs sm={12} item direction="column">
+            {listing?.readMoreUrl ? (
+              <Link href={listing.readMoreUrl} passHref>
+                <MuiLink target="_blank" color="text.primary">
+                  <Typography variant="h4" component="h4" align="center" gutterBottom>
+                    {listing?.organization.name}
+                  </Typography>
+                </MuiLink>
+              </Link>
+            ) : (
+              <Typography variant="h4" component="h4" align="center" gutterBottom>
+                {listing?.organization.name}
+              </Typography>
+            )}
+            <Divider sx={{ my: 2, display: { xs: "none", sm: "block" } }} />
             <Typography variant="caption" component="h3" align="center" gutterBottom>
-              {`Frist ${dayjs(listing.deadline).format("DD. MMMM YYYY [kl.] HH:mm")}`}
+              {`Frist ${dayjs(listing?.deadline).format("DD. MMMM YYYY [kl.] HH:mm")}`}
             </Typography>
             {link && (
-              <Box>
+              <Grid container item justifyContent="center">
                 <Link href={link} passHref>
                   <Button variant="contained" color="primary" endIcon={<ArrowForward />}>
                     Søk her
                   </Button>
                 </Link>
-              </Box>
+              </Grid>
             )}
-          </Stack>
-        </Stack>
+          </Grid>
+        </Grid>
       </CardContent>
     </Card>
   );

--- a/frontend/src/pages/listings/[...listingId].tsx
+++ b/frontend/src/pages/listings/[...listingId].tsx
@@ -1,18 +1,14 @@
 import { useQuery } from "@apollo/client";
 import * as markdownComponents from "@components/MarkdownForm/components";
-import InfoCard from "@components/pages/listings/detail/InfoCard";
-import ListingBanner from "@components/pages/listings/detail/ListingBanner";
-import ListingBody from "@components/pages/listings/detail/ListingBody";
 import TitleCard from "@components/pages/listings/detail/TitleCard";
-import { ListingDocument, ListingQuery } from "@generated/graphql";
+import Title from "@components/Title";
+import { ListingDocument } from "@generated/graphql";
 import { Listing } from "@interfaces/listings";
-import Layout, { RootStyle } from "@layouts/Layout";
+import Layout from "@layouts/Layout";
 import { addApolloState, initializeApollo } from "@lib/apolloClient";
-import { ArrowForward, OpenInNew } from "@mui/icons-material";
-import { Button, Container, Grid, Hidden, Paper } from "@mui/material";
+import { Container, Grid } from "@mui/material";
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import Head from "next/head";
-import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import { NextPageWithLayout } from "../_app";
 
@@ -34,17 +30,14 @@ const ListingPage: NextPageWithLayout<InferGetServerSidePropsType<typeof getServ
   if (loading) return <p>Loading...</p>;
   if (error) return <p>Error</p>;
 
-  const getLink = (listing: ListingQuery["listing"]): string => {
-    if (listing?.form) {
-      return `/forms/${listing.form.id}`;
-    }
-    return listing?.applicationUrl ?? "";
-  };
-
   return (
     <>
       <Head>
         <title>{`${listing.title} | Foreningen for Studenter ved Industriell Økonomi og Teknologiledelse`}</title>
+        <meta property="og:image" content="img/gang.jpg" key="image" />
+        {listing.organization.logoUrl && (
+          <meta property="og:image" content={listing.organization.logoUrl} key="image" />
+        )}
         {listing.heroImageUrl && <meta property="og:image" content={listing.heroImageUrl} key="image" />}
         <meta
           property="og:title"
@@ -54,93 +47,48 @@ const ListingPage: NextPageWithLayout<InferGetServerSidePropsType<typeof getServ
       </Head>
       {data?.listing && (
         <>
-          <Hidden smDown>
-            <ListingBanner imageUrl={data.listing.heroImageUrl} />
-          </Hidden>
-          <Container>
-            <Grid container justifyContent="center">
-              <Grid
-                container
-                item
-                xs={12}
-                sm={10}
-                direction="column"
-                alignItems="stretch"
-                spacing={4}
-                sx={(theme) => ({
-                  position: "relative",
-                  [theme.breakpoints.up("md")]: {
-                    marginTop: "-7%",
-                  },
-                })}
-              >
-                <Grid container item direction="row" alignItems="stretch" justifyContent="center" spacing={4}>
-                  <Hidden mdDown>
-                    <Grid item xs={4}>
-                      <InfoCard listing={data.listing} />
-                    </Grid>
-                  </Hidden>
-                  <Grid item xs>
-                    <TitleCard listing={data.listing} />
-                  </Grid>
-                </Grid>
-                <Grid item>
-                  <ListingBody>
-                    <ReactMarkdown components={markdownComponents}>
-                      {descriptionWithTitle(data.listing.description)}
-                    </ReactMarkdown>
-                  </ListingBody>
-                </Grid>
+          <Title
+            title={data.listing.title}
+            variant={data.listing.heroImageUrl ? "dark" : "normal"}
+            overline={data.listing.organization.name}
+            breadcrumbs={[
+              { href: "/", name: "Hjem" },
+              { href: "/listings", name: "Verv" },
+              { href: `/listings/${data.listing.id}`, name: data.listing.title },
+            ]}
+            bgImage={data.listing.heroImageUrl ?? undefined}
+            ImageProps={{
+              placeholder: "empty",
+              unoptimized: true,
+              layout: "fill",
+              objectPosition: "top",
+            }}
+          />
+          <Container sx={{ mb: 4 }}>
+            <Grid
+              container
+              direction="row-reverse"
+              justifyContent={{ xs: "center", sm: "space-between" }}
+              alignItems="flex-start"
+              spacing={4}
+            >
+              <Grid item xs={12} sm={6} md={5} direction="column">
+                <TitleCard listing={data.listing} />
+              </Grid>
+              <Grid item xs={12} sm={6} md={7}>
+                <ReactMarkdown components={markdownComponents}>
+                  {descriptionWithTitle(data.listing.description)}
+                </ReactMarkdown>
               </Grid>
             </Grid>
           </Container>
-          <Hidden mdUp>
-            <Paper
-              sx={{
-                position: "sticky",
-                bottom: 0,
-                padding: (theme) => theme.spacing(2),
-                zIndex: (theme) => theme.zIndex.snackbar,
-              }}
-            >
-              <Grid container direction="row" justifyContent="space-between" alignItems="center">
-                {data.listing.readMoreUrl && (
-                  <Grid item xs>
-                    <Link passHref href={data.listing.readMoreUrl}>
-                      <Button size="small" endIcon={<OpenInNew />}>
-                        {data.listing.organization.name.slice(0, 20)}
-                      </Button>
-                    </Link>
-                  </Grid>
-                )}
-                <Hidden smUp>
-                  {(data.listing.form || data.listing.applicationUrl) && (
-                    <Grid item>
-                      <Button
-                        variant="contained"
-                        color="primary"
-                        href={getLink(data.listing)}
-                        endIcon={<ArrowForward />}
-                      >
-                        Søk her
-                      </Button>
-                    </Grid>
-                  )}
-                </Hidden>
-              </Grid>
-            </Paper>
-          </Hidden>
         </>
       )}
     </>
   );
 };
 
-ListingPage.getLayout = (page) => (
-  <Layout>
-    <RootStyle>{page}</RootStyle>
-  </Layout>
-);
+ListingPage.getLayout = (page) => <Layout>{page}</Layout>;
 
 export const getServerSideProps: GetServerSideProps<{ listing: Listing }> = async (ctx) => {
   const client = initializeApollo({}, ctx);

--- a/frontend/src/pages/listings/[...listingId].tsx
+++ b/frontend/src/pages/listings/[...listingId].tsx
@@ -14,21 +14,19 @@ import { NextPageWithLayout } from "../_app";
 
 // page to show details about a listing and its organization
 const ListingPage: NextPageWithLayout<InferGetServerSidePropsType<typeof getServerSideProps>> = ({ listing }) => {
-  const { loading, error, data } = useQuery(ListingDocument, {
+  const { data } = useQuery(ListingDocument, {
     variables: {
       id: listing.id,
     },
   });
 
-  const descriptionWithTitle = (desc: string) => {
+  const descriptionWithTitle = (desc: string | undefined) => {
+    if (desc === undefined) return "";
     if (!desc.startsWith("#")) {
       return "### Om vervet\n" + desc;
     }
     return desc;
   };
-
-  if (loading) return <p>Loading...</p>;
-  if (error) return <p>Error</p>;
 
   return (
     <>
@@ -45,45 +43,41 @@ const ListingPage: NextPageWithLayout<InferGetServerSidePropsType<typeof getServ
           key="title"
         />
       </Head>
-      {data?.listing && (
-        <>
-          <Title
-            title={data.listing.title}
-            variant={data.listing.heroImageUrl ? "dark" : "normal"}
-            overline={data.listing.organization.name}
-            breadcrumbs={[
-              { href: "/", name: "Hjem" },
-              { href: "/listings", name: "Verv" },
-              { href: `/listings/${data.listing.id}`, name: data.listing.title },
-            ]}
-            bgImage={data.listing.heroImageUrl ?? undefined}
-            ImageProps={{
-              placeholder: "empty",
-              unoptimized: true,
-              layout: "fill",
-              objectPosition: "top",
-            }}
-          />
-          <Container sx={{ mb: 4 }}>
-            <Grid
-              container
-              direction="row-reverse"
-              justifyContent={{ xs: "center", sm: "space-between" }}
-              alignItems="flex-start"
-              spacing={4}
-            >
-              <Grid item xs={12} sm={6} md={5} direction="column">
-                <TitleCard listing={data.listing} />
-              </Grid>
-              <Grid item xs={12} sm={6} md={7}>
-                <ReactMarkdown components={markdownComponents}>
-                  {descriptionWithTitle(data.listing.description)}
-                </ReactMarkdown>
-              </Grid>
-            </Grid>
-          </Container>
-        </>
-      )}
+      <Title
+        title={data?.listing?.title}
+        variant={data?.listing?.heroImageUrl ? "dark" : "normal"}
+        overline={data?.listing?.organization.name}
+        breadcrumbs={[
+          { href: "/", name: "Hjem" },
+          { href: "/listings", name: "Verv" },
+          { href: `/listings/${data?.listing?.id}`, name: data?.listing?.title },
+        ]}
+        bgImage={data?.listing?.heroImageUrl ?? undefined}
+        ImageProps={{
+          placeholder: "empty",
+          unoptimized: true,
+          layout: "fill",
+          objectPosition: "top",
+        }}
+      />
+      <Container sx={{ mb: 4 }}>
+        <Grid
+          container
+          direction="row-reverse"
+          justifyContent={{ xs: "center", sm: "space-between" }}
+          alignItems="flex-start"
+          spacing={4}
+        >
+          <Grid item xs={12} sm={6} md={5} direction="column">
+            <TitleCard listing={data?.listing} />
+          </Grid>
+          <Grid item xs={12} sm={6} md={7}>
+            <ReactMarkdown components={markdownComponents}>
+              {descriptionWithTitle(data?.listing?.description)}
+            </ReactMarkdown>
+          </Grid>
+        </Grid>
+      </Container>
     </>
   );
 };


### PR DESCRIPTION
## Proposed Changes

- Restyle listings index page to bring it more in-line with the rest of the site
- Fix `og:image` with appropriate fallbacks
- Utilize `next/future/image` and enable S3 as asset domain
<img width="400" alt="Screenshot 2022-08-24 at 17 50 23" src="https://user-images.githubusercontent.com/46653859/186464438-e26ef54e-1328-445f-8abf-e6ace7b6184b.png">
<img width="400" alt="Screenshot 2022-08-24 at 17 52 10" src="https://user-images.githubusercontent.com/46653859/186464525-8281f906-25a3-484b-b705-ca879954bc28.png">


## Types of Changes

- [ ] New feature
- [x] Bug fix
- [ ] Enhancement/optimization
- [ ] Refactor
- [x] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- Closes #

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [x] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
