### PR TITLE
♻️ refactor: remove `phosphor-react`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,6 @@
     "js-cookie": "^3.0.1",
     "lodash": "^4.17.21",
     "next": "^12.0.8",
-    "phosphor-react": "^1.4.1",
     "react": "^17.0.2",
     "react-awesome-reveal": "^4.0.0",
     "react-dom": "^17.0.2",

--- a/frontend/src/components/Breadcrumbs/index.tsx
+++ b/frontend/src/components/Breadcrumbs/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Breadcrumbs as MUIBreadcrumbs, BreadcrumbsProps, SxProps, Typography } from "@mui/material";
-import { CaretRight } from "phosphor-react";
+import { ChevronRight } from "@mui/icons-material";
 import Link from "./Link";
 import { TLink } from "./types";
 
@@ -49,7 +49,7 @@ const Breadcrumbs: React.FC<Props> = ({ links, sx, activeLast = false, onDark = 
             lineHeight: 0,
           }}
         >
-          <CaretRight width={8} height={8} />
+          <ChevronRight sx={{ fontSize: 12 }} />
         </Box>
       }
       {...other}

--- a/frontend/src/components/DarkModeToggle/index.tsx
+++ b/frontend/src/components/DarkModeToggle/index.tsx
@@ -1,37 +1,11 @@
-import { IconButton } from "@mui/material";
-import { Monitor, Moon, SunDim } from "phosphor-react";
-import { useTernaryDarkMode } from "usehooks-ts";
 import Toggle, { Props as ToggleProps } from "./variants/Toggle";
 
 interface Props extends ToggleProps {
-  variant?: "select" | "toggle";
+  variant?: "toggle";
 }
 
-const DarkModeToggle: React.FC<Props> = ({ variant = "select", ...props }) => {
-  const { ternaryDarkMode, setTernaryDarkMode } = useTernaryDarkMode();
-
-  if (variant === "toggle") return <Toggle {...props} />;
-
-  switch (ternaryDarkMode) {
-    case "light":
-      return (
-        <IconButton onClick={() => setTernaryDarkMode("dark")}>
-          <Moon />
-        </IconButton>
-      );
-    case "dark":
-      return (
-        <IconButton onClick={() => setTernaryDarkMode("system")}>
-          <Monitor />
-        </IconButton>
-      );
-    case "system":
-      return (
-        <IconButton onClick={() => setTernaryDarkMode("light")}>
-          <SunDim />
-        </IconButton>
-      );
-  }
+const DarkModeToggle: React.FC<Props> = ({ variant = "toggle", ...props }) => {
+  return <Toggle {...props} />;
 };
 
 export default DarkModeToggle;

--- a/frontend/src/components/DarkModeToggle/variants/Toggle.tsx
+++ b/frontend/src/components/DarkModeToggle/variants/Toggle.tsx
@@ -1,5 +1,5 @@
 import { ToggleButton, ToggleButtonGroup, ToggleButtonGroupProps } from "@mui/material";
-import { LightMode, SettingsBrightness, DarkMode } from "@mui/icons-material";
+import { LightModeOutlined, SettingsBrightness, DarkModeOutlined } from "@mui/icons-material";
 
 import { useTernaryDarkMode } from "usehooks-ts";
 
@@ -18,13 +18,13 @@ const Toggle: React.FC<Props> = (props) => {
         {...props}
       >
         <ToggleButton value="light" aria-label="Light">
-          <LightMode fontSize="small" />
+          <LightModeOutlined fontSize="small" />
         </ToggleButton>
         <ToggleButton value="system" aria-label="System">
           <SettingsBrightness fontSize="small" />
         </ToggleButton>
         <ToggleButton value="dark" aria-label="Dark">
-          <DarkMode fontSize="small" />
+          <DarkModeOutlined fontSize="small" />
         </ToggleButton>
       </ToggleButtonGroup>
     </>

--- a/frontend/src/components/DarkModeToggle/variants/Toggle.tsx
+++ b/frontend/src/components/DarkModeToggle/variants/Toggle.tsx
@@ -1,5 +1,6 @@
 import { ToggleButton, ToggleButtonGroup, ToggleButtonGroupProps } from "@mui/material";
-import { SunDim, Monitor, Moon } from "phosphor-react";
+import { LightMode, SettingsBrightness, DarkMode } from "@mui/icons-material";
+
 import { useTernaryDarkMode } from "usehooks-ts";
 
 export type Props = ToggleButtonGroupProps;
@@ -17,13 +18,13 @@ const Toggle: React.FC<Props> = (props) => {
         {...props}
       >
         <ToggleButton value="light" aria-label="Light">
-          <SunDim />
+          <LightMode fontSize="small" />
         </ToggleButton>
         <ToggleButton value="system" aria-label="System">
-          <Monitor />{" "}
+          <SettingsBrightness fontSize="small" />
         </ToggleButton>
         <ToggleButton value="dark" aria-label="Dark">
-          <Moon />
+          <DarkMode fontSize="small" />
         </ToggleButton>
       </ToggleButtonGroup>
     </>

--- a/frontend/src/components/NavigationSidebar/NavigationSidebarItem.tsx
+++ b/frontend/src/components/NavigationSidebar/NavigationSidebarItem.tsx
@@ -1,7 +1,7 @@
 import { Box, Collapse, List, ListItemText } from "@mui/material";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
-import { CaretDown, CaretRight } from "phosphor-react";
+import { KeyboardArrowDown, ChevronRight } from "@mui/icons-material";
 import { useState } from "react";
 import { NavigationItem } from ".";
 import { ListItemIconStyle, ListItemStyle, ListSubItemIconStyle } from "./styles";
@@ -29,7 +29,7 @@ const NavigationSidebarItem: React.FC<Props> = ({ item }) => {
           {icon && <ListItemIconStyle>{icon}</ListItemIconStyle>}
           <ListItemText disableTypography primary={title} />
           {info}
-          <Box ml={1}>{open ? <CaretDown width={16} height={16} /> : <CaretRight width={16} height={16} />}</Box>
+          <Box ml={1}>{open ? <KeyboardArrowDown fontSize="small" /> : <ChevronRight fontSize="small" />}</Box>
         </ListItemStyle>
 
         <Collapse in={open} timeout="auto" unmountOnExit>

--- a/frontend/src/components/landing/LandingHero/OrganizationLink.tsx
+++ b/frontend/src/components/landing/LandingHero/OrganizationLink.tsx
@@ -1,6 +1,6 @@
 import { Box, Card, CardActionArea, Stack, Typography } from "@mui/material";
 import Link from "next/link";
-import { Link as LinkIcon } from "phosphor-react";
+import { OpenInNew } from "@mui/icons-material";
 
 type External = {
   externalUrl: string;
@@ -38,7 +38,7 @@ const OrganizationLink: React.FC<Props> = ({ organization }) => {
             <Typography variant="h6" component="p">
               {organization.name}
             </Typography>
-            {organization.externalUrl && <LinkIcon width={20} height={20} />}
+            {organization.externalUrl && <OpenInNew fontSize="small" />}
           </Stack>
         </CardActionArea>
       </Link>

--- a/frontend/src/components/landing/LandingHero/Organizations.tsx
+++ b/frontend/src/components/landing/LandingHero/Organizations.tsx
@@ -1,7 +1,7 @@
 import OrganizationLink, { Organization } from "./OrganizationLink";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { Box, Button, IconButton } from "@mui/material";
-import { ArrowLeft, ArrowRight } from "phosphor-react";
+import { ArrowBack, ArrowForward } from "@mui/icons-material";
 import { styled } from "@mui/system";
 import { FreeMode, Navigation } from "swiper";
 import "swiper/css";
@@ -58,7 +58,7 @@ const Organizations: React.FC<Props> = ({ offsetX, onActiveIndexChange }) => {
   return (
     <>
       <ArrowStyle className="arrow left">
-        <ArrowLeft />
+        <ArrowBack />
       </ArrowStyle>
       <Box
         sx={{ "& .swiper-slide": { my: "auto" }, "& .swiper": { overflow: "visible" } }}
@@ -97,7 +97,7 @@ const Organizations: React.FC<Props> = ({ offsetX, onActiveIndexChange }) => {
           ))}
           <SwiperSlide>
             <Link passHref href="/about/organization">
-              <Button color="inherit" variant="contained" size="large" endIcon={<ArrowRight />}>
+              <Button color="inherit" variant="contained" size="large" endIcon={<ArrowForward />}>
                 Alle organisasjoner
               </Button>
             </Link>
@@ -105,7 +105,7 @@ const Organizations: React.FC<Props> = ({ offsetX, onActiveIndexChange }) => {
         </Swiper>
       </Box>
       <ArrowStyle className="arrow right">
-        <ArrowRight />
+        <ArrowForward />
       </ArrowStyle>
     </>
   );

--- a/frontend/src/components/pages/about/AboutPageArrow.tsx
+++ b/frontend/src/components/pages/about/AboutPageArrow.tsx
@@ -1,6 +1,6 @@
+import { ChevronLeft, ChevronRight } from "@mui/icons-material";
 import { Avatar, Box, CardActionArea, Grid, Stack, Typography } from "@mui/material";
 import NextLink from "next/link";
-import { CaretLeft, CaretRight } from "phosphor-react";
 
 type AboutPostProps = {
   slug: string;
@@ -25,7 +25,7 @@ const AboutPageArrow: React.FC<Props> = ({ prevPost, nextPost }) => {
             href={prevSlug}
             title={prevPost?.title}
             coverImg={prevPost?.cover}
-            icon={<Box component={CaretLeft} sx={{ width: 24, height: 24, color: "text.disabled", flexShrink: 0 }} />}
+            icon={<Box component={ChevronLeft} sx={{ width: 24, height: 24, color: "text.disabled", flexShrink: 0 }} />}
           />
         )}
       </Grid>
@@ -37,7 +37,9 @@ const AboutPageArrow: React.FC<Props> = ({ prevPost, nextPost }) => {
             isNext
             title={nextPost?.title}
             coverImg={nextPost?.cover}
-            icon={<Box component={CaretRight} sx={{ width: 24, height: 24, color: "text.disabled", flexShrink: 0 }} />}
+            icon={
+              <Box component={ChevronRight} sx={{ width: 24, height: 24, color: "text.disabled", flexShrink: 0 }} />
+            }
           />
         )}
       </Grid>

--- a/frontend/src/components/pages/archive/SearchBar.tsx
+++ b/frontend/src/components/pages/archive/SearchBar.tsx
@@ -1,6 +1,6 @@
 import { InputAdornment, OutlinedInput, Toolbar } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import { MagnifyingGlass } from "phosphor-react";
+import { Search } from "@mui/icons-material";
 
 interface SearchBarProps {
   searchFilter: string;
@@ -36,7 +36,7 @@ const SearchBar: React.FC<SearchBarProps> = ({ searchFilter, handleSearchFilterC
         placeholder="Søk etter dokumenter..."
         startAdornment={
           <InputAdornment position="start">
-            <MagnifyingGlass />
+            <Search />
           </InputAdornment>
         }
       />

--- a/frontend/src/components/pages/cabins/BookNow.tsx
+++ b/frontend/src/components/pages/cabins/BookNow.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@apollo/client";
 import { CabinsAndResponsiblesDocument } from "@generated/graphql";
-import { ArrowRight } from "phosphor-react";
+import { ArrowForward } from "@mui/icons-material";
 import { Button, Card, CardContent, Divider, Stack, Typography } from "@mui/material";
 import Link from "next/link";
 import React from "react";
@@ -32,7 +32,7 @@ const BookNow: React.FC = () => {
             <Typography variant="subtitle2">Ekstern: 270 kr</Typography>
           </Stack>
           <Link href="/cabins/book" passHref>
-            <Button variant="contained" size="large" color="success" endIcon={<ArrowRight />}>
+            <Button variant="contained" size="large" color="success" endIcon={<ArrowForward />}>
               Book nå
             </Button>
           </Link>

--- a/frontend/src/components/pages/cabins/ContactCabinBoard/index.tsx
+++ b/frontend/src/components/pages/cabins/ContactCabinBoard/index.tsx
@@ -2,8 +2,8 @@ import { useQuery } from "@apollo/client";
 import LabeledIcon from "@components/LabeledIcon";
 import { QUERY_BOOKING_RESPONSIBLE } from "@graphql/cabins/queries";
 import { BookingResponsible } from "@interfaces/cabins";
+import { MailOutline } from "@mui/icons-material";
 import { Link, Stack, Typography } from "@mui/material";
-import { Envelope } from "phosphor-react";
 import React from "react";
 
 const ContactCabinBoard: React.FC = () => {
@@ -14,7 +14,7 @@ const ContactCabinBoard: React.FC = () => {
       <Stack direction="column" spacing={2} mb={4}>
         <Typography variant="subtitle1">Spørsmål?</Typography>
         <LabeledIcon
-          icon={<Envelope size="24px" />}
+          icon={<MailOutline />}
           value={
             <Typography variant="body1" sx={{ ml: 1 }}>
               <Link href={`mailto:${data?.activeBookingResponsible.email}`}>

--- a/frontend/src/components/pages/events/EventDetails.tsx
+++ b/frontend/src/components/pages/events/EventDetails.tsx
@@ -32,7 +32,16 @@ import { calendarFile } from "@utils/calendars";
 import dayjs from "dayjs";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { CalendarBlank, CreditCard, Envelope, Gear, GraduationCap, MapPin, Pencil, SquaresFour } from "phosphor-react";
+import {
+  PlaceOutlined,
+  CreditCardRounded,
+  MailOutline,
+  SettingsRounded,
+  SchoolRounded,
+  CreateRounded,
+  WidgetsOutlined,
+  CalendarTodayOutlined,
+} from "@mui/icons-material";
 import React, { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import CountdownButton from "./CountdownButton";
@@ -267,7 +276,7 @@ const EventDetails: React.FC<Props> = ({ eventId }) => {
               <Button
                 variant="contained"
                 color="inherit"
-                startIcon={<Pencil />}
+                startIcon={<CreateRounded />}
                 onClick={() => {
                   setOpenEditEvent(true);
                 }}
@@ -275,7 +284,7 @@ const EventDetails: React.FC<Props> = ({ eventId }) => {
                 Rediger
               </Button>
               <Link href={`/orgs/${event.organization.id}/events/${eventId}`} passHref>
-                <Button variant="contained" color="inherit" startIcon={<Gear />}>
+                <Button variant="contained" color="inherit" startIcon={<SettingsRounded />}>
                   Administrer
                 </Button>
               </Link>
@@ -300,7 +309,7 @@ const EventDetails: React.FC<Props> = ({ eventId }) => {
                   <LabeledIcon
                     spacing={2}
                     alignItems="flex-start"
-                    icon={<CreditCard size={24} />}
+                    icon={<CreditCardRounded />}
                     value={
                       <Stack>
                         <Typography variant="subtitle2">Pris</Typography>
@@ -315,7 +324,7 @@ const EventDetails: React.FC<Props> = ({ eventId }) => {
                   <LabeledIcon
                     spacing={2}
                     alignItems="flex-start"
-                    icon={<MapPin size={24} />}
+                    icon={<PlaceOutlined />}
                     value={
                       <Stack>
                         <Typography variant="subtitle2">Sted</Typography>
@@ -330,7 +339,7 @@ const EventDetails: React.FC<Props> = ({ eventId }) => {
                   <LabeledIcon
                     spacing={2}
                     alignItems="flex-start"
-                    icon={<SquaresFour size={24} />}
+                    icon={<WidgetsOutlined />}
                     value={
                       <Stack>
                         <Typography variant="subtitle2">Kategori</Typography>
@@ -345,7 +354,7 @@ const EventDetails: React.FC<Props> = ({ eventId }) => {
                   <LabeledIcon
                     spacing={2}
                     alignItems="flex-start"
-                    icon={<Envelope size={24} />}
+                    icon={<MailOutline />}
                     value={
                       <Stack>
                         <Typography variant="subtitle2">Kontakt</Typography>
@@ -360,7 +369,7 @@ const EventDetails: React.FC<Props> = ({ eventId }) => {
                 <LabeledIcon
                   spacing={2}
                   alignItems="flex-start"
-                  icon={<CalendarBlank size={24} />}
+                  icon={<CalendarTodayOutlined />}
                   value={
                     <Stack>
                       <Typography variant="subtitle2">Starter</Typography>
@@ -375,7 +384,7 @@ const EventDetails: React.FC<Props> = ({ eventId }) => {
                   <LabeledIcon
                     spacing={2}
                     alignItems="flex-start"
-                    icon={<CalendarBlank size={24} />}
+                    icon={<CalendarTodayOutlined />}
                     value={
                       <Stack>
                         <Typography variant="subtitle2">Slutter</Typography>
@@ -390,7 +399,7 @@ const EventDetails: React.FC<Props> = ({ eventId }) => {
                   <LabeledIcon
                     spacing={2}
                     alignItems="flex-start"
-                    icon={<GraduationCap size={24} />}
+                    icon={<SchoolRounded />}
                     value={
                       <Stack spacing={0.5}>
                         <Typography variant="subtitle2">Åpent for trinn</Typography>

--- a/frontend/src/components/pages/events/filterMenu/FilterMenu.tsx
+++ b/frontend/src/components/pages/events/filterMenu/FilterMenu.tsx
@@ -1,7 +1,6 @@
 import { FilterQuery } from "@components/pages/events/AllEvents";
+import { Refresh, StarOutlineRounded, StarRounded } from "@mui/icons-material";
 import { Card, CardContent, Divider, Grid, IconButton, Tooltip, Typography } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
-import { Star, X } from "phosphor-react";
 import React from "react";
 import CategoryFilter from "./CategoryFilter";
 import DateTimeFilter from "./DateTimeFilter";
@@ -26,8 +25,6 @@ type Props = {
  */
 
 const FilterMenu: React.FC<Props> = ({ filters, onFiltersChange, showDefaultEvents, onShowDefaultChange }) => {
-  const theme = useTheme();
-
   const handleChecked: HandleChecked = (e, field, filter) => {
     if (e.target.checked) {
       onFiltersChange({ ...filters, [field]: filter });
@@ -46,7 +43,7 @@ const FilterMenu: React.FC<Props> = ({ filters, onFiltersChange, showDefaultEven
             <Grid item>
               <Tooltip title="Nullstill filter" arrow>
                 <IconButton onClick={() => onFiltersChange({})} aria-label="delete">
-                  <X />
+                  <Refresh />
                 </IconButton>
               </Tooltip>
             </Grid>
@@ -60,7 +57,7 @@ const FilterMenu: React.FC<Props> = ({ filters, onFiltersChange, showDefaultEven
             </Grid>
             <Grid item>
               <IconButton onClick={() => onShowDefaultChange(!showDefaultEvents)} aria-label="delete">
-                {showDefaultEvents ? <Star color={theme.palette.secondary.main} weight="fill" /> : <Star />}
+                {showDefaultEvents ? <StarRounded color="secondary" /> : <StarOutlineRounded />}
               </IconButton>
             </Grid>
           </Grid>

--- a/frontend/src/layouts/components/LoginButton.tsx
+++ b/frontend/src/layouts/components/LoginButton.tsx
@@ -4,7 +4,7 @@ import { GET_USER_INFO } from "@graphql/users/queries";
 import { UserInfo } from "@interfaces/users";
 import { Button } from "@mui/material";
 import NextLink from "next/link";
-import { User } from "phosphor-react";
+import { PersonOutlineRounded } from "@mui/icons-material";
 
 type Props = {
   fullWidth?: boolean;
@@ -17,7 +17,7 @@ const LoginButton: React.FC<Props> = ({ fullWidth, "data-test-id": dataTestId })
   return (
     <LoginRequired size="medium" color="inherit" data-test-id={dataTestId} fullWidth={fullWidth}>
       <NextLink href="/profile" passHref>
-        <Button endIcon={<User />} variant="outlined" color="inherit" size="medium">
+        <Button endIcon={<PersonOutlineRounded fontSize="small" />} variant="outlined" color="inherit" size="medium">
           {data?.user?.firstName}
         </Button>
       </NextLink>

--- a/frontend/src/layouts/navigation/index.tsx
+++ b/frontend/src/layouts/navigation/index.tsx
@@ -1,4 +1,5 @@
 import dynamic from "next/dynamic";
+import { useRouter } from "next/router";
 import { routes } from "./constants";
 
 const Drawer = dynamic(() => import("./variants/Drawer"));
@@ -9,9 +10,10 @@ const Basic = dynamic(() => import("./variants/Basic"));
  * app bar navigation depending on screen size.
  */
 const Navigation: React.FC = () => {
+  const { route } = useRouter();
   return (
     <>
-      <Drawer routes={routes} />
+      <Drawer key={route} routes={routes} />
       <Basic routes={routes} />
     </>
   );

--- a/frontend/src/layouts/navigation/variants/Drawer/index.tsx
+++ b/frontend/src/layouts/navigation/variants/Drawer/index.tsx
@@ -1,9 +1,9 @@
 import { PermissionRequired } from "@components/Auth";
 import Logo from "@components/Logo";
 import LoginButton from "@layouts/components/LoginButton";
+import { Menu } from "@mui/icons-material";
 import { Box, Divider, Drawer as MuiDrawer, IconButton, Stack } from "@mui/material";
 import { useRouter } from "next/router";
-import { List } from "phosphor-react";
 import { useState } from "react";
 import { NavigationProps } from "../../types";
 import NavigationLink from "./NavigationLink";
@@ -17,7 +17,7 @@ const Drawer: React.FC<NavigationProps> = ({ routes }) => {
     <Box sx={{ display: { xs: "block", md: "none" }, width: "100%" }}>
       <Stack direction="row" justifyContent="flex-end" sx={{ width: "100%" }}>
         <IconButton onClick={() => setOpen(true)} sx={{ color: "text.secondary" }}>
-          <List alt="Meny" />
+          <Menu aria-label="menu" />
         </IconButton>
         <MuiDrawer
           open={open}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5751,11 +5751,6 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
 
-phosphor-react@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/phosphor-react/-/phosphor-react-1.4.1.tgz#97b0e034d9937db9b97fe53b186e9646464fd4e7"
-  integrity sha512-gO5j7U0xZrdglTAYDYPACU4xDOFBTJmptrrB/GeR+tHhCZF3nUMyGmV/0hnloKjuTrOmpSFlbfOY78H39rgjUQ==
-
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"


### PR DESCRIPTION
## Proposed Changes

- Phosphor icons are nice, but the package does not allow for similar transformation as `@mui/icons-material`, resulting in us pulling in a lot of icons when developing locally, contributing to a severe slow-down of hot reloading in NextJS. This PR replaces the Phosphor icons with similar MUI icons, which also ensures consistency across the site.

## Types of Changes

- [ ] New feature
- [ ] Bug fix
- [x] Enhancement/optimization
- [x] Refactor
- [ ] Style
- [ ] Build/dependencies
- [ ] Other

## Issue(s) fixed or closed by this PR

- Closes #

## Checklist

- [ ] I have added tests to cover my changes (for features/bugs)
- [x] I am pleased with the readability of the code (if not, state where you need input)
- [X] I have tested the changes and verified that they work and do not break anything (to the best of my ability)
