### PR TITLE
simplify github pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,3 @@
-## Proposed Changes
+### Changes
 
 -
-
-## Types of Changes
-
-- [ ] New feature
-- [ ] Bug fix
-- [ ] Enhancement/optimization
-- [ ] Refactor
-- [ ] Style
-- [ ] Build/dependencies
-- [ ] Other
-
-## Issue(s) fixed or closed by this PR
-
-- Closes #
-
-## Checklist
-
-- [ ] I have added tests to cover my changes (for features/bugs)
-- [ ] I am pleased with the readability of the code (if not, state where you need input)
-- [ ] I have tested the changes and verified that they work and do not break anything (to the best of my ability)


### PR DESCRIPTION
### Changes

- change the github pull request template to be as simple as possible

### Rationale

The current Pull Request template is quite verbose, and most of the points are often disregarded. In my opinion, this raises the barrier for submitting PRs, when it should be as low as possible. This PR makes the template as simple as possible: a list of changes. If a PR author wishes to include more (like I have, for the Rationale here), they can add it themselves, rather than being forced into the template's format.