### PR TITLE
permissions: change query to use .graphql instead of .ts

### DIFF
--- a/frontend/src/components/Auth/PermissionRequired/index.tsx
+++ b/frontend/src/components/Auth/PermissionRequired/index.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@apollo/client";
 
-import { HAS_PERMISSION } from "@/graphql/permissions/queries";
+import { HasPermissionDocument } from "@/generated/graphql";
 
 type Props = {
   permission: string;
@@ -8,12 +8,7 @@ type Props = {
 };
 
 const PermissionRequired: React.FC<Props> = ({ permission, fallback, children }) => {
-  const { data } = useQuery<{ hasPermission: boolean }>(HAS_PERMISSION, {
-    variables: {
-      permission,
-    },
-    ssr: false,
-  });
+  const { data } = useQuery(HasPermissionDocument, { variables: { permission }, ssr: false });
 
   if (data?.hasPermission) return <>{children}</>;
   return <>{fallback}</>;

--- a/frontend/src/graphql/permissions/queries.ts
+++ b/frontend/src/graphql/permissions/queries.ts
@@ -1,7 +1,0 @@
-import { gql } from "@apollo/client";
-
-export const HAS_PERMISSION = gql`
-  query hasPermission($permission: String!) {
-    hasPermission(permission: $permission)
-  }
-`;


### PR DESCRIPTION
### Changes

- change `hasPermission` query in `PermissionRequired` component to use generated query instead of `.ts` query
