### PR TITLE
show button for sending booking request on mobile

### DIFF
--- a/frontend/src/pages/cabins/book/index.tsx
+++ b/frontend/src/pages/cabins/book/index.tsx
@@ -135,14 +135,14 @@ const CabinBookingPage: NextPageWithLayout = () => {
       placement="left"
       disableHoverListener={stepReady[activeStep].ready}
     >
-      <Box display={activeStep == 4 ? "none" : "block"}>
+      <Box display={"block"}>
         <Button
           onClick={handleNextClick}
           disabled={!stepReady[activeStep].ready}
           size={isMobile ? "small" : "large"}
           variant="contained"
         >
-          {activeStep == 3 ? "Send søknad" : "Neste"}
+          {activeStep == 3 ? "Send" : "Neste"}
           <KeyboardArrowRight />
         </Button>
       </Box>
@@ -150,7 +150,7 @@ const CabinBookingPage: NextPageWithLayout = () => {
   );
 
   const BackButton = () => (
-    <Box display={activeStep == 4 ? "none" : "block"} sx={{ opacity: activeStep === 0 ? 0 : 1 }}>
+    <Box display={"block"} sx={{ opacity: activeStep === 0 ? 0 : 1 }}>
       <Button
         size={isMobile ? "small" : "large"}
         onClick={() => setActiveStep((prev) => prev - 1)}
@@ -235,7 +235,7 @@ const CabinBookingPage: NextPageWithLayout = () => {
             </Card>
           ))}
       </Stack>
-      {isMobile && activeStep != 3 ? (
+      {isMobile ? (
         <MobileStepper
           steps={4}
           position="bottom"

--- a/frontend/src/pages/cabins/book/index.tsx
+++ b/frontend/src/pages/cabins/book/index.tsx
@@ -135,7 +135,7 @@ const CabinBookingPage: NextPageWithLayout = () => {
       placement="left"
       disableHoverListener={stepReady[activeStep].ready}
     >
-      <Box display={"block"}>
+      <Box display={activeStep == 4 ? "none" : "block"}>
         <Button
           onClick={handleNextClick}
           disabled={!stepReady[activeStep].ready}
@@ -150,7 +150,7 @@ const CabinBookingPage: NextPageWithLayout = () => {
   );
 
   const BackButton = () => (
-    <Box display={"block"} sx={{ opacity: activeStep === 0 ? 0 : 1 }}>
+    <Box display={activeStep == 4 ? "none" : "block"} sx={{ opacity: activeStep === 0 ? 0 : 1 }}>
       <Button
         size={isMobile ? "small" : "large"}
         onClick={() => setActiveStep((prev) => prev - 1)}


### PR DESCRIPTION
### Changes

- Show MobileStepper on stage 3, not sure why this was explicitly hidden before?
- (Might have been a mistake seeing as its not supposed to show on stage 4)
- Also changed "send søknad" to "send". Its obvious what you are sending, and also it fits and looks better when viewed on mobile 😄 
