### PR TITLE
🐛 fix: include extra information for sign ups in exports and overview

### DIFF
--- a/backend/apps/events/resolvers.py
+++ b/backend/apps/events/resolvers.py
@@ -22,6 +22,7 @@ DEFAULT_REPORT_FIELDS = {
     "signup_user_grade_year",
     "signup_user_email",
     "signup_user_phone_number",
+    "signup_extra_information",
     "user_allergies",
     "attendance_status",
     "order_timestamp",

--- a/frontend/src/components/pages/orgs/events/Table.tsx
+++ b/frontend/src/components/pages/orgs/events/Table.tsx
@@ -62,6 +62,7 @@ export const AttendeeTable: React.FC<Props> = ({ attendees, tickets, eventId }) 
                 E-mail
               </Typography>
             </TableCell>
+            <TableCell>Ekstra informasjon</TableCell>
             <TableCell />
           </TableRow>
         </TableHead>
@@ -72,12 +73,19 @@ export const AttendeeTable: React.FC<Props> = ({ attendees, tickets, eventId }) 
                 <TableCell>{attendee.hasBoughtTicket ? <Check color="success" /> : <Close color="error" />}</TableCell>
               )}
               <TableCell>
-                {attendee.user.firstName} {attendee.user.lastName}
+                <Typography variant="inherit" noWrap>
+                  {attendee.user.firstName} {attendee.user.lastName}
+                </Typography>
               </TableCell>
               <TableCell>{attendee.userGradeYear}</TableCell>
               <TableCell>{attendee.userAllergies}</TableCell>
               <TableCell>{attendee.userPhoneNumber}</TableCell>
               <TableCell>{attendee.userEmail}</TableCell>
+              <TableCell>
+                <Typography maxWidth="20rem" noWrap textOverflow="ellipsis" variant="inherit">
+                  {attendee.extraInformation}
+                </Typography>
+              </TableCell>
               <TableCell>
                 <IconButton
                   onClick={() =>

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1853,6 +1853,7 @@ export type AdminEventFragment = {
     userGradeYear: number;
     userAllergies?: string | null;
     userPhoneNumber: string;
+    extraInformation: string;
     hasBoughtTicket?: boolean | null;
     user: { __typename?: "UserType"; id: string; firstName: string; lastName: string };
   }> | null;
@@ -1862,6 +1863,7 @@ export type AdminEventFragment = {
     userGradeYear: number;
     userAllergies?: string | null;
     userPhoneNumber: string;
+    extraInformation: string;
     user: { __typename?: "UserType"; id: string; firstName: string; lastName: string };
   }> | null;
   userAttendance?: {
@@ -1878,6 +1880,7 @@ export type SignUpFragment = {
   userGradeYear: number;
   userAllergies?: string | null;
   userPhoneNumber: string;
+  extraInformation: string;
   user: { __typename?: "UserType"; id: string; firstName: string; lastName: string };
 };
 
@@ -1887,6 +1890,7 @@ export type SignUpWithTicketFragment = {
   userGradeYear: number;
   userAllergies?: string | null;
   userPhoneNumber: string;
+  extraInformation: string;
   hasBoughtTicket?: boolean | null;
   user: { __typename?: "UserType"; id: string; firstName: string; lastName: string };
 };
@@ -2228,6 +2232,7 @@ export type AdminEventQuery = {
       userGradeYear: number;
       userAllergies?: string | null;
       userPhoneNumber: string;
+      extraInformation: string;
       hasBoughtTicket?: boolean | null;
       user: { __typename?: "UserType"; id: string; firstName: string; lastName: string };
     }> | null;
@@ -2237,6 +2242,7 @@ export type AdminEventQuery = {
       userGradeYear: number;
       userAllergies?: string | null;
       userPhoneNumber: string;
+      extraInformation: string;
       user: { __typename?: "UserType"; id: string; firstName: string; lastName: string };
     }> | null;
     userAttendance?: {
@@ -3601,6 +3607,7 @@ export const SignUpWithTicketFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "userGradeYear" } },
           { kind: "Field", name: { kind: "Name", value: "userAllergies" } },
           { kind: "Field", name: { kind: "Name", value: "userPhoneNumber" } },
+          { kind: "Field", name: { kind: "Name", value: "extraInformation" } },
           { kind: "Field", name: { kind: "Name", value: "hasBoughtTicket" } },
         ],
       },
@@ -3633,6 +3640,7 @@ export const SignUpFragmentDoc = {
           { kind: "Field", name: { kind: "Name", value: "userGradeYear" } },
           { kind: "Field", name: { kind: "Name", value: "userAllergies" } },
           { kind: "Field", name: { kind: "Name", value: "userPhoneNumber" } },
+          { kind: "Field", name: { kind: "Name", value: "extraInformation" } },
         ],
       },
     },

--- a/frontend/src/graphql/events/fragments.graphql
+++ b/frontend/src/graphql/events/fragments.graphql
@@ -140,6 +140,7 @@ fragment SignUp on SignUpType {
   userGradeYear
   userAllergies
   userPhoneNumber
+  extraInformation
 }
 
 fragment SignUpWithTicket on SignUpType {
@@ -152,5 +153,6 @@ fragment SignUpWithTicket on SignUpType {
   userGradeYear
   userAllergies
   userPhoneNumber
+  extraInformation
   hasBoughtTicket
 }


### PR DESCRIPTION
### Changes

- Add extra information to the list of exported fields in the export resolver
- Add a column for extra information in the events overview on the organization page
- Add a `noWrap` to the name column in the same table
