### PR TITLE
Fix/change arkiv to documents

### DIFF
--- a/frontend/src/layouts/navigation/constants.tsx
+++ b/frontend/src/layouts/navigation/constants.tsx
@@ -7,6 +7,6 @@ export const routes: Route[] = [
   },
   { title: "Verv", path: "/listings" },
   { title: "Hyttebooking", path: "/cabins" },
-  { title: "Arkiv", path: "/archive", permission: "archive.view_archivedocument" },
+  { title: "Dokumenter", path: "/archive", permission: "archive.view_archivedocument" },
   { title: "Om oss", path: "/about" },
 ];

--- a/frontend/src/pages/archive.tsx
+++ b/frontend/src/pages/archive.tsx
@@ -36,10 +36,10 @@ const Archive: NextPageWithLayout<InferGetServerSidePropsType<typeof getServerSi
   return (
     <>
       <Title
-        title="Arkiv"
+        title="Dokumenter"
         breadcrumbs={[
           { name: "Hjem", href: "/" },
-          { name: "Arkiv", href: "/archive" },
+          { name: "Dokumenter", href: "/archive" },
         ]}
       />
 


### PR DESCRIPTION
### Changes

- Change name from "Arkiv" to "Dokumenter" per request
- Multiple people find it confusing that important documents are stored under archive instead of documents
- Still maintains the purpose of the page
