### PR TITLE
👷 ci(dependabot): approve and enable auto-merge for dependabot patch PR

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -16,6 +16,7 @@ jobs:
         uses: dependabot/fetch-metadata@v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,44 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  approve:
+    # Approves all Dependabot PRs
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+  automerge:
+    # Enables automerge for Patch PRs from Dependabot
+    # Following semver, patch updates should not break anything,
+    # and therefore, having to manually approve and merge them
+    # can be tedious.
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{contains(steps.metadata.outputs.dependency-names, 'my-dependency') && steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,6 +1,9 @@
 name: Dependabot auto-merge
 on: pull_request
 
+# Sourced from
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#approve-a-pull-request
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
### Motivation
The _vast_ majority of our dependencies follow [Semantic Versioning](https://semver.org). While I recommend reading the documentation, it basically boils down to three different kinds of updates: <MAJOR>.<MINOR>.<PATCH>. Where PATCH is bug fixing, no breaking changes. As these are the most frequent kinds of updates, it can be quite tedious and redundant to manually approve and merge such PRs from Dependabot. Therefore, this PR adds auto-approval to all dependabot PRs, and enables automerge for PATCH updates.

Retrieved from [Automating Dependabot with GitHub Actions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#approve-a-pull-request)

### Changes

- Add workflow to automatically approve all Dependabot PRs
- Add job to enable automerge for Dependabot PATCH PRs
