### PR TITLE
🐛 fix: use static url for thumbnails

### DIFF
--- a/backend/apps/archive/types.py
+++ b/backend/apps/archive/types.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import graphene
 from graphene_django import DjangoObjectType
 
@@ -9,3 +11,7 @@ class ArchiveDocumentType(DjangoObjectType):
 
     class Meta:
         model = ArchiveDocument
+
+    @staticmethod
+    def resolve_thumbnail(instance: ArchiveDocument, info) -> Optional[str]:
+        return f"https://drive.google.com/thumbnail?authuser=0&sz=w320&id={instance.file_location}"

--- a/backend/schema.json
+++ b/backend/schema.json
@@ -3316,6 +3316,18 @@
                 "name": "Boolean",
                 "ofType": null
               }
+            },
+            {
+              "args": [],
+              "deprecationReason": null,
+              "description": null,
+              "isDeprecated": false,
+              "name": "positionOnWaitingList",
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
             }
           ],
           "inputFields": null,

--- a/frontend/src/generated/graphql.tsx
+++ b/frontend/src/generated/graphql.tsx
@@ -1780,7 +1780,6 @@ export type EventFragment = {
     isSignedUp?: boolean | null;
     isOnWaitingList?: boolean | null;
     hasBoughtTicket?: boolean | null;
-    positionOnWaitingList?: number | null;
   } | null;
   product?: { __typename?: "ProductType"; id: string } | null;
 };
@@ -1991,7 +1990,6 @@ export type UpdateEventMutation = {
         isSignedUp?: boolean | null;
         isOnWaitingList?: boolean | null;
         hasBoughtTicket?: boolean | null;
-        positionOnWaitingList?: number | null;
       } | null;
       product?: { __typename?: "ProductType"; id: string } | null;
     } | null;
@@ -2084,7 +2082,6 @@ export type EventQuery = {
       isSignedUp?: boolean | null;
       isOnWaitingList?: boolean | null;
       hasBoughtTicket?: boolean | null;
-      positionOnWaitingList?: number | null;
     } | null;
     product?: { __typename?: "ProductType"; id: string } | null;
   } | null;
@@ -3491,7 +3488,6 @@ export const EventFragmentDoc = {
                 { kind: "Field", name: { kind: "Name", value: "isSignedUp" } },
                 { kind: "Field", name: { kind: "Name", value: "isOnWaitingList" } },
                 { kind: "Field", name: { kind: "Name", value: "hasBoughtTicket" } },
-                { kind: "Field", name: { kind: "Name", value: "positionOnWaitingList" } },
               ],
             },
           },


### PR DESCRIPTION
### Changes

- [Thumbnail links typically only last a few hours](https://developers.google.com/drive/api/v3/reference/files), so storing them does not work. Instead, use a static URL combined with the file ID.
