### PR TITLE
:zap: perf: use next image for about/organization

### DIFF
--- a/frontend/src/pages/about/organization.tsx
+++ b/frontend/src/pages/about/organization.tsx
@@ -1,39 +1,53 @@
-import { Card, CardActionArea, CardContent, CardMedia, Stack, Tab, Tabs, Typography } from "@mui/material";
+import { Box, Card, CardActionArea, CardContent, CardMedia, Tab, Tabs, Typography } from "@mui/material";
 import Grid from "@mui/material/Grid";
-import { styled } from "@mui/material/styles";
-import { GetStaticProps } from "next";
+import { GetStaticProps, InferGetStaticPropsType } from "next";
 import Image from "next/image";
 import Router, { useRouter } from "next/router";
 import React from "react";
 
-import { Link } from "@/components";
+import { NextLinkComposed } from "@/components";
 import { TabPanel } from "@/components/pages/about/TabPanel";
 import { Template } from "@/components/pages/about/Template";
 import { Layout } from "@/layouts/Layout";
 import { NextPageWithLayout } from "@/lib/next";
-import { getSortedPosts } from "@/utils/posts";
+import { Article, getSortedPosts } from "@/utils/posts";
 
-type Post = {
-  frontmatter: {
-    title: string;
-    image?: string;
-    tag?: string;
-    logo: string;
-  };
+type InternalProps = {
   slug: string;
+  href?: never;
+};
+
+type ExternalProps = {
+  slug?: never;
+  href: string;
 };
 
 type Props = {
-  posts: Post[];
-} & Post;
+  organization: {
+    title: string;
+    logo?: string;
+  };
+} & (InternalProps | ExternalProps);
 
-const StyledCardMedia = styled(CardMedia)(() => ({
-  height: "100px",
-  width: "100%",
-  backgroundSize: "contain",
-  backgroundPosition: "center",
-  alignContent: "center",
-}));
+const OrganizationCard: React.FC<Props> = ({ organization, slug, href }) => {
+  const to = typeof slug !== "undefined" ? `/about/organizations/${slug}` : href;
+  return (
+    <Card sx={{ height: "100%" }}>
+      <CardActionArea to={to} component={NextLinkComposed} sx={{ height: "100%" }}>
+        {organization.logo && (
+          <CardMedia sx={{ position: "relative", height: "150px" }}>
+            <Image src={organization.logo} alt={organization.title} fill style={{ objectFit: "contain" }} />
+          </CardMedia>
+        )}
+        <CardContent>
+          <Typography variant="body1" textAlign="center">
+            {organization.title}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+};
 
 const routes: { [key: string]: { id: number; title: string } } = {
   alle: {
@@ -54,7 +68,7 @@ const routes: { [key: string]: { id: number; title: string } } = {
   },
 };
 
-const OrganizationPage: NextPageWithLayout<Props> = ({ posts }) => {
+const OrganizationPage: NextPageWithLayout<InferGetStaticPropsType<typeof getStaticProps>> = ({ posts }) => {
   const router = useRouter();
   const value = typeof router.query.category == "string" ? routes[router.query.category].id : 0;
 
@@ -87,29 +101,41 @@ const OrganizationPage: NextPageWithLayout<Props> = ({ posts }) => {
       prevPost={{ title: "Om oss", slug: "/about", cover: "/img/hero.jpg" }}
       nextPost={{ title: "Les om Hovedstyret", slug: "/about/board", cover: "/img/hero.jpg" }}
     >
-      <Stack direction="column" height={460} position="relative">
-        <Image src="/img/organisasjonskart2023.svg" alt="Foreningskart" fill />
-      </Stack>
-      <Typography id="orgList" variant="h3" component="h2" gutterBottom>
+      <Box height={460} position="relative">
+        <Image src="/img/organisasjonskart2023.svg" alt="Foreningskart" fill priority />
+      </Box>
+
+      <Typography variant="h3" component="h2" gutterBottom>
         Se foreningene våre under
       </Typography>
-      <Tabs indicatorColor="primary" value={value} onChange={pushQuery}>
+
+      <Tabs indicatorColor="primary" value={value} onChange={pushQuery} sx={{ mb: 2 }}>
         {Object.keys(routes).map((keyName, i) => (
           <Tab key={i} label={routes[keyName].title} />
         ))}
       </Tabs>
-      <br />
 
       <TabPanel value={value} index={1}>
-        Indøk Kultur er paraplyforeningen for alle kulturaktiviteter på Indøk, og innbefatter Indøkrevyen, Mannskoret
-        Klingende Mynt, et Indøk-band (Bandøk), et ølbryggerlag (Indøl) samt en veldedig organisasjon (IVI).
+        <Card variant="outlined" elevation={0} sx={{ mb: 2 }}>
+          <CardContent>
+            <Typography>
+              Indøk Kultur er paraplyforeningen for alle kulturaktiviteter på Indøk, og innbefatter Indøkrevyen,
+              Mannskoret Klingende Mynt, et Indøk-band (Bandøk), et ølbryggerlag (Indøl) samt en veldedig organisasjon
+              (IVI).
+            </Typography>
+          </CardContent>
+        </Card>
       </TabPanel>
       <TabPanel value={value} index={2}>
-        <Typography>
-          Fra en sped start som Janus FK i 2006, har foreningen vokst til å forene godt over hundre sporty og engasjerte
-          studenter under én felles paraply, med et bredt spekter av idretter. Tilbudet blir stadig bredere, og ønsker
-          og idéer til nye lag og idretter tas alltid imot med åpne armer!
-        </Typography>
+        <Card variant="outlined" elevation={0} sx={{ mb: 2 }}>
+          <CardContent>
+            <Typography>
+              Fra en sped start som Janus FK i 2006, har foreningen vokst til å forene godt over hundre sporty og
+              engasjerte studenter under én felles paraply, med et bredt spekter av idretter. Tilbudet blir stadig
+              bredere, og ønsker og idéer til nye lag og idretter tas alltid imot med åpne armer!
+            </Typography>
+          </CardContent>
+        </Card>
       </TabPanel>
 
       <Grid container spacing={2}>
@@ -117,70 +143,28 @@ const OrganizationPage: NextPageWithLayout<Props> = ({ posts }) => {
           .filter((post) => (router.query.category != undefined ? post.frontmatter.tag == router.query.category : post))
           .map(({ frontmatter: { title, logo }, slug }) => (
             <Grid key={slug} item xs={12} sm={6} md={4}>
-              <Card sx={{ height: "100%" }}>
-                <CardActionArea
-                  href={`/about/organizations/${slug}`}
-                  noLinkStyle
-                  component={Link}
-                  sx={{ height: "100%" }}
-                >
-                  <CardContent sx={{ justifyContent: "center" }}>
-                    {logo ? <StyledCardMedia image={logo} sx={{ mb: 2 }} /> : ""}
-                    <Typography variant="body2" textAlign="center">
-                      {title}
-                    </Typography>
-                  </CardContent>
-                </CardActionArea>
-              </Card>
+              <OrganizationCard organization={{ title, logo }} slug={slug} />
             </Grid>
           ))}
         {(router.query.category == undefined || router.query.category == "annet") && (
           <>
             <Grid item xs={12} sm={6} md={4}>
-              <Card sx={{ height: "100%" }}>
-                <CardActionArea href="https://bindeleddet.no/" noLinkStyle component={Link} sx={{ height: "100%" }}>
-                  <CardContent sx={{ justifyContent: "center" }}>
-                    <StyledCardMedia image="/img/bindeleddetlogo.png" sx={{ mb: 2 }} />
-                    <Typography variant="body2" textAlign="center">
-                      Bindeleddet
-                    </Typography>
-                  </CardContent>
-                </CardActionArea>
-              </Card>
+              <OrganizationCard
+                organization={{ title: "Bindeleddet", logo: "/img/bindeleddetlogo.png" }}
+                href="https://bindeleddet.no/"
+              />
             </Grid>
             <Grid item xs={12} sm={6} md={4}>
-              <Card sx={{ height: "100%" }}>
-                <CardActionArea
-                  href="https://sites.google.com/view/estiem-ntnu"
-                  noLinkStyle
-                  component={Link}
-                  sx={{ height: "100%" }}
-                >
-                  <CardContent sx={{ justifyContent: "center" }}>
-                    <StyledCardMedia image="/img/estiemlogo.png" sx={{ mb: 2 }} />
-                    <Typography variant="body2" textAlign="center">
-                      ESTIEM
-                    </Typography>
-                  </CardContent>
-                </CardActionArea>
-              </Card>
+              <OrganizationCard
+                organization={{ title: "ESTIEM", logo: "/img/estiemlogo.png" }}
+                href="https://sites.google.com/view/estiem-ntnu"
+              />
             </Grid>
             <Grid item xs={12} sm={6} md={4}>
-              <Card sx={{ height: "100%" }}>
-                <CardActionArea
-                  href="https://januslinjeforening.no/"
-                  noLinkStyle
-                  component={Link}
-                  sx={{ height: "100%" }}
-                >
-                  <CardContent sx={{ justifyContent: "center" }}>
-                    <StyledCardMedia image="/img/januslogo.png" sx={{ mb: 2 }} />
-                    <Typography variant="body2" textAlign="center">
-                      Janus
-                    </Typography>
-                  </CardContent>
-                </CardActionArea>
-              </Card>
+              <OrganizationCard
+                organization={{ title: "Janus", logo: "/img/januslogo.png" }}
+                href="https://januslinjeforening.no/"
+              />
             </Grid>
           </>
         )}
@@ -191,7 +175,7 @@ const OrganizationPage: NextPageWithLayout<Props> = ({ posts }) => {
 
 OrganizationPage.getLayout = (page) => <Layout>{page}</Layout>;
 
-export const getStaticProps: GetStaticProps = async () => {
+export const getStaticProps: GetStaticProps<{ posts: Article[] }> = async () => {
   const posts = getSortedPosts("organizations");
 
   return {

--- a/frontend/src/utils/posts.ts
+++ b/frontend/src/utils/posts.ts
@@ -14,6 +14,7 @@ type Frontmatter = {
   title: string;
   logo?: string;
   alt?: string;
+  tag?: string;
   image?: string;
   board: Record<string, BoardMember>;
 };


### PR DESCRIPTION
### Changes

- Minor clean up, extract card into separate component
- Use next/image instead of default card media for improved performance
