### PR TITLE
:zap: perf: use next font, update to latest mui/next example

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -24,6 +24,8 @@ const getPresets = () => {
  * @type {import('next').NextConfig}
  */
 const moduleExports = {
+  reactStrictMode: true,
+
   /** @todo internationalized routing */
   async rewrites() {
     return [

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -10,11 +10,11 @@ import { AppProvider } from "@/providers";
 
 initializeDayjs();
 
-export type CustomAppProps = AppProps<PageProps> & {
+export interface CustomAppProps extends AppProps<PageProps> {
   err: Error;
   Component: NextPageWithLayout;
   emotionCache?: EmotionCache;
-};
+}
 
 const App = (props: CustomAppProps): JSX.Element => {
   const { pageProps, err, Component, emotionCache } = props;

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -1,49 +1,44 @@
 import createEmotionServer from "@emotion/server/create-instance";
 import { getInitColorSchemeScript } from "@mui/material/styles";
-import Document, { Head, Html, Main, NextScript } from "next/document";
+import { AppType } from "next/app";
+import Document, { DocumentContext, DocumentProps, Head, Html, Main, NextScript } from "next/document";
 
 import { createEmotionCache } from "@/lib/emotion";
+import { poppins, merriweather } from "@/theme/typography";
 
-export default class MyDocument extends Document {
-  render() {
-    return (
-      <Html lang="en">
-        <Head>
-          <meta charSet="utf-8" />
+import { CustomAppProps } from "./_app";
 
-          {/* Fonts */}
-          <link rel="preconnect" href="https://fonts.googleapis.com" />
-          <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+interface MyDocumentProps extends DocumentProps {
+  emotionStyleTags: JSX.Element[];
+}
 
-          <link
-            href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap"
-            rel="stylesheet"
-          />
-          <link
-            href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700;900&display=swap"
-            rel="stylesheet"
-          />
-          <meta name="emotion-insertion-point" content="" />
-          {(this.props as any).emotionStyleTags}
-        </Head>
-        <body>
-          {getInitColorSchemeScript({
-            defaultMode: "system",
-            colorSchemeStorageKey: "color-scheme",
-            modeStorageKey: "mode",
-            attribute: "data-color-scheme",
-          })}
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    );
-  }
+export default function MyDocument({ emotionStyleTags }: MyDocumentProps) {
+  return (
+    <Html lang="en" className={`${poppins.className} ${merriweather.className}`}>
+      <Head>
+        <meta charSet="utf-8" />
+
+        <link rel="shortcut icon" href="/favicon.ico" />
+        <meta name="emotion-insertion-point" content="" />
+        {emotionStyleTags}
+      </Head>
+      <body>
+        {getInitColorSchemeScript({
+          defaultMode: "system",
+          colorSchemeStorageKey: "color-scheme",
+          modeStorageKey: "mode",
+          attribute: "data-color-scheme",
+        })}
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
 }
 
 // `getInitialProps` belongs to `_document` (instead of `_app`),
 // it's compatible with static-site generation (SSG).
-MyDocument.getInitialProps = async (ctx) => {
+MyDocument.getInitialProps = async (ctx: DocumentContext) => {
   // Resolution order
   //
   // On the server:
@@ -75,7 +70,7 @@ MyDocument.getInitialProps = async (ctx) => {
 
   ctx.renderPage = () =>
     originalRenderPage({
-      enhanceApp: (App: any) =>
+      enhanceApp: (App: React.ComponentType<React.ComponentProps<AppType> & Pick<CustomAppProps, "emotionCache">>) =>
         function EnhanceApp(props) {
           return <App emotionCache={cache} {...props} />;
         },

--- a/frontend/src/theme/typography/index.ts
+++ b/frontend/src/theme/typography/index.ts
@@ -1,7 +1,22 @@
 import { ThemeOptions } from "@mui/material";
+import { Poppins, Merriweather } from "next/font/google";
 
-const PRIMARY = "Poppins, sans-serif";
-const SECONDARY = "Merriweather, sans-serif";
+export const poppins = Poppins({
+  display: "swap",
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  fallback: ["ui-sans-serif"],
+});
+
+export const merriweather = Merriweather({
+  display: "swap",
+  subsets: ["latin"],
+  weight: ["400", "700", "900"],
+  fallback: ["ui-serif"],
+});
+
+const PRIMARY = poppins.style.fontFamily;
+const SECONDARY = merriweather.style.fontFamily;
 
 export const typography: ThemeOptions["typography"] = {
   fontFamily: PRIMARY,


### PR DESCRIPTION
### Changes

- Use next/font instead of google fonts
