### PR TITLE
chore: add sentry edge config, update to latest with-sentry example

### DIFF
--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -1,0 +1,20 @@
+// This file configures the initialization of Sentry on the server.
+// The config you add here will be used whenever the server handles a request.
+// https://docs.sentry.io/platforms/javascript/guides/nextjs/
+
+import { init } from "@sentry/nextjs";
+
+import { config } from "@/utils/config";
+
+const SENTRY_DSN = config.APP_ENV === "production" ? config.SENTRY_DSN : undefined;
+
+init({
+  dsn: SENTRY_DSN,
+  // Adjust this value in production, or use tracesSampler for greater control
+  tracesSampleRate: 1.0,
+  // ...
+  // Note: if you want to override the automatic release value, do not set a
+  // `release` value here - use the environment variable `SENTRY_RELEASE`, so
+  // that it will also get attached to your source maps
+  environment: config.APP_ENV,
+});

--- a/frontend/src/pages/_error.tsx
+++ b/frontend/src/pages/_error.tsx
@@ -1,8 +1,21 @@
+/**
+ * This page is loaded by Nextjs:
+ *  - on the server, when data-fetching methods throw or reject
+ *  - on the client, when `getInitialProps` throws or rejects
+ *  - on the client, when a React lifecycle method throws or rejects, and it's
+ *    caught by the built-in Nextjs error boundary
+ *
+ * See:
+ *  - https://nextjs.org/docs/basic-features/data-fetching/overview
+ *  - https://nextjs.org/docs/api-reference/data-fetching/get-initial-props
+ *  - https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
+ */
+
 import { captureUnderscoreErrorException } from "@sentry/nextjs";
 import { NextPageContext } from "next";
 import NextErrorComponent, { ErrorProps as NextErrorProps } from "next/error";
 
-export type ErrorPageProps = {
+export type ErrorComponentProps = {
   err: Error;
   statusCode: number;
   isReadyToRender: boolean;
@@ -12,14 +25,17 @@ export type ErrorProps = {
   isReadyToRender: boolean;
 } & NextErrorProps;
 
-const ErrorPage = (props: ErrorPageProps): JSX.Element => {
-  captureUnderscoreErrorException(props);
-  return <NextErrorComponent statusCode={props.statusCode} />;
-};
+const ErrorComponent = (props: ErrorComponentProps): JSX.Element => (
+  <NextErrorComponent statusCode={props.statusCode} />
+);
 
-ErrorPage.getInitialProps = async (contextData: NextPageContext & { [key: string]: unknown }) => {
+ErrorComponent.getInitialProps = async (contextData: NextPageContext & { [key: string]: unknown }) => {
+  // In case this is running in a serverless function, await this in order to give Sentry
+  // time to send the error before the lambda exits
   await captureUnderscoreErrorException(contextData);
+
+  // This will contain the status code of the response
   return NextErrorComponent.getInitialProps(contextData);
 };
 
-export default ErrorPage;
+export default ErrorComponent;


### PR DESCRIPTION
### Changes

- [with-sentry](https://github.com/vercel/next.js/tree/canary/examples/with-sentry)
