### PR TITLE
fix(events): fallback with `""` short description

### DIFF
--- a/frontend/src/components/pages/events/EventListItem.tsx
+++ b/frontend/src/components/pages/events/EventListItem.tsx
@@ -35,7 +35,7 @@ export const EventListItem: React.FC<Props> = ({ event, user }) => {
 
               <Typography variant="body2">Dato: {dayjs(event.startTime).format("LLL")}</Typography>
 
-              <Typography variant="body2">{event.shortDescription ?? "Trykk for å lese mer"}</Typography>
+              <Typography variant="body2">{event.shortDescription || "Trykk for å lese mer"}</Typography>
             </Stack>
             <StatusChip event={event} user={{ ...event.userAttendance, gradeYear: user?.gradeYear }} />
           </Stack>


### PR DESCRIPTION
### Changes

- Use logical or `||` instead of nullish coalescing operator `??` when determining fallback for no short description. Also catches `""`, i.e. the empty string