### PR TITLE
chore(deps): bump @types/node to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ If you want to close the backend, press `Ctrl + C` in the terminal where it runs
      - Use `cd` to navigate to where you downloaded the `.exe` file (e.g. `cd downloads`)
      - Type `.\nvm-setup.exe`, and go through the installer
    - Type `nvm version` in a new terminal to check that it was installed correctly
-2. Type `nvm install --lts` in the terminal to install the Long Term Support (LTS) version of Node.
-3. Type `nvm use --lts`, where `--lts` is the version shown in the terminal after running the previous command
+2. Type `nvm install --lts` in the terminal to install the current long-term support (LTS) version of Node.
+3. Type `nvm use --lts`
    - If on Windows, you may have to run the terminal as administrator
 4. Open the `indok-web` folder in VSCode, and create a file called `.env.local`
 5. Ask the project maintainers for dev environment variables

--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ If you want to close the backend, press `Ctrl + C` in the terminal where it runs
      - Use `cd` to navigate to where you downloaded the `.exe` file (e.g. `cd downloads`)
      - Type `.\nvm-setup.exe`, and go through the installer
    - Type `nvm version` in a new terminal to check that it was installed correctly
-2. Type `nvm install 16` in the terminal to install Node.js version 16
-3. Type `nvm use 16.X.Y`, where `16.X.Y` is the version shown in the terminal after running the previous command
+2. Type `nvm install --lts` in the terminal to install the Long Term Support (LTS) version of Node.
+3. Type `nvm use --lts`, where `--lts` is the version shown in the terminal after running the previous command
    - If on Windows, you may have to run the terminal as administrator
 4. Open the `indok-web` folder in VSCode, and create a file called `.env.local`
 5. Ask the project maintainers for dev environment variables

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,7 @@
     "@graphql-typed-document-node/core": "^3.2.0",
     "@next/bundle-analyzer": "^13.4.1",
     "@types/lodash": "^4.14.194",
-    "@types/node": "^16.18.25",
+    "@types/node": "18",
     "@types/react": "18",
     "@types/react-dom": "18",
     "@types/react-swipeable-views": "^0.13.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1906,15 +1906,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.18.tgz#3b4fed5cfb58010e3a2be4b6e74615e4847f1074"
   integrity sha512-eKj4f/BsN/qcculZiRSujogjvp5O/k4lOW5m35NopjZM/QwLOR075a8pJW5hD+Rtdm2DaCVPENS6KtSQnUD6BA==
 
+"@types/node@18":
+  version "18.16.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.14.tgz#ab67bb907f1146afc6fedb9ce60ae8a99c989631"
+  integrity sha512-+ImzUB3mw2c5ISJUq0punjDilUQ5GnUim0ZRvchHIWJmOC0G+p0kzhXBqj6cDjK0QdPFwzrHWgrJp3RPvCG5qg==
+
 "@types/node@^14.14.31":
   version "14.18.21"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.21.tgz#0155ee46f6be28b2ff0342ca1a9b9fd4468bef41"
   integrity sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q==
-
-"@types/node@^16.18.25":
-  version "16.18.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.25.tgz#8863940fefa1234d3fcac7a4b7a48a6c992d67af"
-  integrity sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==
 
 "@types/parse-json@^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
### Changes

- 18 is LTS, and is what we're actually using.
- Update installation instructions in the readme to clarify that we should be using LTS, not 16.
