### PR TITLE
:bug: fix: don't return children if the permission is falsy

### DIFF
--- a/frontend/src/app/components/PermissionRequired/index.tsx
+++ b/frontend/src/app/components/PermissionRequired/index.tsx
@@ -29,10 +29,8 @@ function BackgroundQueryPermissionRequired<T extends HasPermissionQuery>(
   const { queryRef, children } = props;
   const { data } = useReadQuery(queryRef);
 
-  if (data.hasPermission === null) {
-    return null;
-  }
-  return <>{children}</>;
+  if (data.hasPermission) return <>{children}</>;
+  return null;
 }
 
 const hasPermissionDocument = graphql(/* GraphQL */ `
@@ -53,8 +51,6 @@ function QueryPermissionRequired(props: PropsWithChildren<PermissionRequiredProp
     },
   });
 
-  if (data?.hasPermission === null) {
-    return null;
-  }
-  return <>{children}</>;
+  if (data?.hasPermission) return <>{children}</>;
+  return null;
 }


### PR DESCRIPTION
### Changes

- Return `null` if permission is falsy, otherwise render children.
