### PR TITLE
:bug: fix: only show next week's events

### DIFF
--- a/frontend/src/components/pages/events/AllEvents.tsx
+++ b/frontend/src/components/pages/events/AllEvents.tsx
@@ -99,13 +99,13 @@ export const AllEvents: React.FC = () => {
     const eventDate = dayjs(event.startTime);
     const nextWeek = dayjs().add(1, "week");
     const twoWeeks = dayjs().add(2, "week");
-    return eventDate.isBetween(nextWeek, twoWeeks, "week", "[]");
+    return eventDate.isBetween(nextWeek, twoWeeks, "week", "[)");
   });
 
   const futureEvents = userRelevantEvents.filter((event) => {
     const eventDate = dayjs(event.startTime);
     const twoWeeks = dayjs().add(2, "week");
-    return eventDate.isAfter(twoWeeks, "week");
+    return eventDate.isSameOrAfter(twoWeeks, "week");
   });
 
   return (


### PR DESCRIPTION
### Changes

- Right now, we filter next week's events with an inclusive between, so we display all events that between 1 and 2 weeks in the future. This PR fixes that by not including events that are two weeks ahead using only a left-inclusive between.
- Events that are > 1 week in the future are moved to "Fremtidige Arrangementer"


#### Before
<img width="300" alt="Before the change, events that are more than one week in the future are displayed under the header 'Next Week'" src="https://github.com/rubberdok/indok-web/assets/46653859/c4928b2d-5ea0-41c3-8bdd-1976cb517e06">


#### After
<img width="300" alt="After the change, events that are more than one week in the future are displayed under the header 'Future Events'" src="https://github.com/rubberdok/indok-web/assets/46653859/bf9f30ff-25fc-4869-afa3-f86c58c52232">
