### PR TITLE
:bug: fix: infinite re-renders when booking cabins

### DIFF
--- a/frontend/src/pages/cabins/book/index.tsx
+++ b/frontend/src/pages/cabins/book/index.tsx
@@ -13,7 +13,7 @@ import {
   Tooltip,
   Typography,
 } from "@mui/material";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { ContractDialog } from "@/components/pages/cabins/Popup/ContractDialog";
 import { StepComponent } from "@/components/pages/cabins/StepComponent";
@@ -34,14 +34,6 @@ type StepReady = Record<number, { ready: boolean; errortext: string }>;
 
 const steps = ["Book hytte", "Kontaktinfo", "Ekstra info", "Send søknad", "Kvittering"];
 
-const initalStepReady: StepReady = steps.reduce((initialObject, _step, index) => {
-  initialObject[index] = {
-    ready: false,
-    errortext: "",
-  };
-  return initialObject;
-}, {} as StepReady);
-
 const defaultContactInfo: ContactInfo = {
   firstName: "",
   lastName: "",
@@ -61,21 +53,36 @@ const defaultModalData: ModalData = {
  * The page renders different components depending on the step variable chosen.
  */
 const CabinBookingPage: NextPageWithLayout = () => {
+  // Which step of the booking process we're on
   const [activeStep, setActiveStep] = useState(0);
-  const [stepReady, setStepReady] = useState<StepReady>(initalStepReady);
+  // Which cabins the user has chosen
+  const [chosenCabins, setChosenCabins] = useState<CabinFragment[]>([]);
+  // Which range of dates the user has chosen
+  const [datePick, setDatePick] = useState<DatePick>({});
+  // The contact info the user has given
+  const [contactInfo, setContactInfo] = useState<ContactInfo>(defaultContactInfo);
+
+  const { data } = useQuery(CabinsDocument);
+
+  /**
+   * Rudimentary validation of the form.
+   * For step 0, we check that the user has chosen cabins and a valid date range
+   * For step 1, we check that the user has filled out all the fields
+   * For step 2 and 3, we don't need to check anything
+   */
+  const stepReady: StepReady = {
+    0: cabinOrderStepReady(chosenCabins, datePick),
+    1: { ready: isFormValid(contactInfo), errortext: "Du må fylle ut alle felt for å gå videre" },
+    2: { ready: true, errortext: "" },
+    3: { ready: true, errortext: "" },
+  };
+
+  // Validation of the contact info
+  const validations: ContactInfoValidations = validateInputForm(contactInfo);
+  const errorTrigger = allValuesFilled(contactInfo);
 
   // Choose cabin
-  const [chosenCabins, setChosenCabins] = useState<CabinFragment[]>([]);
-  const { data } = useQuery(CabinsDocument);
   const [modalData, setModalData] = useState<ModalData>(defaultModalData);
-
-  // Check in/Check out
-  const [datePick, setDatePick] = useState<DatePick>({});
-
-  // Contact info state
-  const [contactInfo, setContactInfo] = useState<ContactInfo>(defaultContactInfo);
-  const [validations, setValidations] = useState<ContactInfoValidations>();
-  const [errorTrigger, setErrorTrigger] = useState(false);
 
   // Booking creation and email mutations
   const [createBooking] = useMutation(CreateBookingDocument);
@@ -83,26 +90,6 @@ const CabinBookingPage: NextPageWithLayout = () => {
 
   // Extra info from the user, sent to Hytteforeningen
   const [extraInfo, setExtraInfo] = useState("");
-
-  useEffect(() => {
-    setStepReady({
-      ...stepReady,
-      0: cabinOrderStepReady(chosenCabins, datePick),
-    });
-  }, [chosenCabins, datePick, stepReady]);
-
-  useEffect(() => {
-    setValidations(validateInputForm(contactInfo));
-    if (allValuesFilled(contactInfo)) {
-      setErrorTrigger(true);
-    }
-    setStepReady({
-      ...stepReady,
-      1: { ready: isFormValid(contactInfo), errortext: "Du må fylle ut alle felt for å gå videre" },
-      2: { ready: true, errortext: "" },
-      3: { ready: true, errortext: "" },
-    });
-  }, [contactInfo, stepReady]);
 
   const handleNextClick = () => {
     if (activeStep == 2 && !modalData.contractViewed) {
@@ -122,8 +109,9 @@ const CabinBookingPage: NextPageWithLayout = () => {
             bookingData: generateEmailAndBookingInput(contactInfo, datePick, chosenCabins, extraInfo),
           },
         });
+      } else {
+        setActiveStep((prev) => prev + 1);
       }
-      setActiveStep((prev) => prev + 1);
     }
   };
 

--- a/frontend/src/pages/cabins/book/index.tsx
+++ b/frontend/src/pages/cabins/book/index.tsx
@@ -57,12 +57,25 @@ const CabinBookingPage: NextPageWithLayout = () => {
   const [activeStep, setActiveStep] = useState(0);
   // Which cabins the user has chosen
   const [chosenCabins, setChosenCabins] = useState<CabinFragment[]>([]);
-  // Which range of dates the user has chosen
-  const [datePick, setDatePick] = useState<DatePick>({});
-  // The contact info the user has given
-  const [contactInfo, setContactInfo] = useState<ContactInfo>(defaultContactInfo);
 
   const { data } = useQuery(CabinsDocument);
+  const [modalData, setModalData] = useState<ModalData>(defaultModalData);
+
+  // Which range of dates the user has chosen
+  const [datePick, setDatePick] = useState<DatePick>({});
+
+  // The contact info the user has given
+  const [contactInfo, setContactInfo] = useState<ContactInfo>(defaultContactInfo);
+  // Validation of the contact info
+  const validations: ContactInfoValidations = validateInputForm(contactInfo);
+  const errorTrigger = allValuesFilled(contactInfo);
+
+  // Booking creation and email mutations
+  const [createBooking] = useMutation(CreateBookingDocument);
+  const [sendEmail] = useMutation(SendEmailDocument);
+
+  // Extra info from the user, sent to Hytteforeningen
+  const [extraInfo, setExtraInfo] = useState("");
 
   /**
    * Rudimentary validation of the form.
@@ -76,20 +89,6 @@ const CabinBookingPage: NextPageWithLayout = () => {
     2: { ready: true, errortext: "" },
     3: { ready: true, errortext: "" },
   };
-
-  // Validation of the contact info
-  const validations: ContactInfoValidations = validateInputForm(contactInfo);
-  const errorTrigger = allValuesFilled(contactInfo);
-
-  // Choose cabin
-  const [modalData, setModalData] = useState<ModalData>(defaultModalData);
-
-  // Booking creation and email mutations
-  const [createBooking] = useMutation(CreateBookingDocument);
-  const [sendEmail] = useMutation(SendEmailDocument);
-
-  // Extra info from the user, sent to Hytteforeningen
-  const [extraInfo, setExtraInfo] = useState("");
 
   const handleNextClick = () => {
     if (activeStep == 2 && !modalData.contractViewed) {


### PR DESCRIPTION
### Changes

- Replace `useEffect` with variables that are derived from state instead of states that are synced with `useEffect`. This change fixes the infinite render cycle that prevents users from proceeding with bookings.

Cabins are overdue for an overhaul, but the scope of this PR is intentionally kept small and just addresses the immediate issue.
