### PR TITLE
♻️ refactor: make stylistic eslint errors `warn` instead of `error`

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -31,7 +31,7 @@ module.exports = {
   },
   rules: {
     "prettier/prettier": [
-      "error",
+      "warn",
       {},
       {
         usePrettierrc: true,
@@ -39,13 +39,12 @@ module.exports = {
     ],
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/ban-ts-ignore": "off",
-    "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
     "import/default": "off",
     "import/no-named-as-default-member": "off",
     "import/no-named-as-default": "off",
     "import/order": [
-      "error",
+      "warn",
       {
         groups: ["builtin", "external", "internal", "parent", "sibling", "index", "object"],
         "newlines-between": "always",

--- a/frontend/src/pages/about/organization.tsx
+++ b/frontend/src/pages/about/organization.tsx
@@ -71,7 +71,7 @@ const OrganizationPage: NextPageWithLayout<InferGetStaticPropsType<typeof getSta
   const router = useRouter();
   const value = typeof router.query.category == "string" ? routes[router.query.category].id : 0;
 
-  const pushQuery = (_: React.ChangeEvent<any>, value: number) => {
+  const pushQuery = (_: React.SyntheticEvent<Element, Event>, value: number) => {
     if (value != 0) {
       Router.push(
         {

--- a/frontend/src/utils/posts.ts
+++ b/frontend/src/utils/posts.ts
@@ -32,7 +32,7 @@ export type Article = {
   prev?: Article | null;
 };
 
-const isFrontMatter = (obj: Record<string, any>): obj is Frontmatter => {
+const isFrontMatter = (obj: Record<string, unknown>): obj is Frontmatter => {
   return obj.description !== undefined && obj.title !== undefined;
 };
 


### PR DESCRIPTION
### Changes

- Make stylistic errors no longer blocking
- Remove rule that permits the use of `any`