### PR TITLE
feat: updated shadows, organization slider & all-events layout

### DIFF
--- a/frontend/src/app/_components/LandingHero/Organizations.tsx
+++ b/frontend/src/app/_components/LandingHero/Organizations.tsx
@@ -1,12 +1,12 @@
-import { ArrowBack, ArrowForward } from "@mui/icons-material";
 import { Box, Button, IconButton } from "@mui/material";
 import { styled } from "@mui/system";
 import Link from "next/link";
-import { FreeMode, Navigation } from "swiper";
-import { Swiper, SwiperSlide } from "swiper/react";
+import { FreeMode, Mousewheel, Navigation } from "swiper";
 import "swiper/css";
+import { Swiper, SwiperSlide } from "swiper/react";
 
-import { OrganizationLink, Organization } from "./OrganizationLink";
+import { ArrowLeft, ArrowRight } from "@mui/icons-material";
+import { Organization, OrganizationLink } from "./OrganizationLink";
 
 const organizations: Readonly<Organization[]> = [
   { name: "Janus", internalUrl: "/janus/info" },
@@ -55,28 +55,38 @@ type Props = {
   onActiveIndexChange: (index: number) => void;
 };
 
-export const Organizations: React.FC<Props> = ({ offsetX, onActiveIndexChange }) => {
+const Organizations: React.FC<Props> = ({ offsetX, onActiveIndexChange }) => {
   return (
     <>
-      <ArrowStyle className="arrow left" aria-label="Forrige">
-        <ArrowBack />
+      <ArrowStyle className="arrow left">
+        <ArrowLeft />
       </ArrowStyle>
       <Box
-        sx={{ "& .swiper-slide": { my: "auto" }, "& .swiper": { overflow: "visible" } }}
+        sx={{
+          "& .swiper-slide": { my: "auto" },
+          "& .swiper": { overflow: "visible" },
+          overscrollBehavior: "none",
+        }}
         position="absolute"
         right={0}
         width={`calc(100vw - ${offsetX}px)`}
       >
         <Swiper
-          modules={[Navigation, FreeMode]}
+          modules={[Navigation, FreeMode, Mousewheel]}
           onActiveIndexChange={(swiper) => onActiveIndexChange(swiper.activeIndex)}
           navigation={{ nextEl: ".arrow.right", prevEl: ".arrow.left" }}
           spaceBetween={16}
+          mousewheel={{
+            forceToAxis: true,
+          }}
           slidesPerView={0.8}
           freeMode={{
             enabled: true,
-            momentumRatio: 0.5,
-            momentumVelocityRatio: 0.5,
+            momentum: true,
+            momentumRatio: 0.25,
+            momentumVelocityRatio: 0.25,
+            minimumVelocity: 0.05,
+            momentumBounce: false,
           }}
           breakpoints={{
             930: {
@@ -98,16 +108,18 @@ export const Organizations: React.FC<Props> = ({ offsetX, onActiveIndexChange })
           ))}
           <SwiperSlide>
             <Link passHref href="/about/organization">
-              <Button color="primary" variant="contained" size="large" endIcon={<ArrowForward />}>
+              <Button color="secondary" variant="contained" size="large" endIcon={<ArrowRight />}>
                 Alle organisasjoner
               </Button>
             </Link>
           </SwiperSlide>
         </Swiper>
       </Box>
-      <ArrowStyle className="arrow right" aria-label="Neste">
-        <ArrowForward />
+      <ArrowStyle className="arrow right">
+        <ArrowRight />
       </ArrowStyle>
     </>
   );
 };
+
+export default Organizations;

--- a/frontend/src/app/_components/LandingHero/Organizations.tsx
+++ b/frontend/src/app/_components/LandingHero/Organizations.tsx
@@ -1,3 +1,4 @@
+import { ArrowLeft, ArrowRight } from "@mui/icons-material";
 import { Box, Button, IconButton } from "@mui/material";
 import { styled } from "@mui/system";
 import Link from "next/link";
@@ -5,7 +6,6 @@ import { FreeMode, Mousewheel, Navigation } from "swiper";
 import "swiper/css";
 import { Swiper, SwiperSlide } from "swiper/react";
 
-import { ArrowLeft, ArrowRight } from "@mui/icons-material";
 import { Organization, OrganizationLink } from "./OrganizationLink";
 
 const organizations: Readonly<Organization[]> = [

--- a/frontend/src/app/_components/LandingHero/OrganizationsSlider.tsx
+++ b/frontend/src/app/_components/LandingHero/OrganizationsSlider.tsx
@@ -1,78 +1,67 @@
 "use client";
 
-import { ArrowForward } from "@mui/icons-material";
-import { Button, Container, NoSsr, Stack, Typography } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
-// Import Swiper React components
-import { Swiper, SwiperSlide } from "swiper/react";
+import { Box, Container, Stack, Typography } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+import Organizations from "./Organizations";
 
-// Import Swiper styles
-import "swiper/css";
+const OrganizationsSlider: React.FC = () => {
+  const orgsTitleEl = useRef<HTMLElement>();
 
-import { Link } from "@/app/components/Link";
+  const [sliderActiveIndex, setSliderActiveIndex] = useState(0);
+  const [sliderOffsetX, setSliderOffsetX] = useState(0);
 
-import { Organization, OrganizationLink } from "./OrganizationLink";
+  const onActiveIndexChange = (index: number) => {
+    setSliderActiveIndex(index);
+  };
 
-const organizations: Readonly<Organization[]> = [
-  { name: "Janus Sosial", internalUrl: "/janus" },
-  { name: "Bindeleddet", externalUrl: "https://www.bindeleddet.no" },
-  { name: "ESTIEM", externalUrl: "https://sites.google.com/view/estiem-ntnu" },
-  { name: "Janus Kultur", internalUrl: "/about/organization?category=kultur" },
-  { name: "Rubberdøk", internalUrl: "/about/organizations/rubberdok" },
-  { name: "Janushyttene", internalUrl: "/about/organizations/Janushyttene" },
-  { name: "Janus IF", internalUrl: "/about/organization?category=idrett" },
-] as const;
+  const updateSliderOffset = () => {
+    if (orgsTitleEl.current) {
+      setSliderOffsetX(orgsTitleEl.current.offsetWidth + orgsTitleEl.current.offsetLeft);
+    }
+  };
 
-export const OrganizationsSlider: React.FC = () => {
-  const theme = useTheme();
+  useEffect(() => {
+    updateSliderOffset();
+    window.addEventListener("resize", updateSliderOffset);
+    return () => {
+      window.removeEventListener("resize", updateSliderOffset);
+    };
+  }, []);
 
   return (
-    <Container maxWidth={false} disableGutters sx={{ bgcolor: "background.elevated" }}>
+    <Box
+      sx={{
+        width: "100%",
+        py: { xs: 4, md: 6 },
+        px: 1,
+        bgcolor: "background.elevated",
+        borderTop: "1px solid",
+        borderBottom: "1px solid",
+        borderColor: "divider",
+        overflow: "hidden",
+        position: "relative",
+        overscrollBehavior: "none",
+      }}
+    >
       <Container>
-        <Stack
-          direction="row"
-          sx={{
-            "& .swiper-slide": {
-              width: "min-content",
-              display: "flex",
-              alignItems: "center",
-            },
-            minHeight: `calc(2rem + ${theme.spacing(15)})`,
-          }}
-        >
-          <NoSsr>
-            <Swiper cssMode spaceBetween={parseInt(theme.spacing(4))} slidesPerView="auto" direction="horizontal">
-              <SwiperSlide>
-                <Typography variant="h4" component="h2">
-                  Våre
-                  <br />
-                  foreninger
-                </Typography>
-              </SwiperSlide>
-              {organizations.map((org) => (
-                <SwiperSlide key={org.name} style={{ padding: theme.spacing(4, 0) }}>
-                  <OrganizationLink organization={org} />
-                </SwiperSlide>
-              ))}
-              <SwiperSlide>
-                <Button
-                  component={Link}
-                  noLinkStyle
-                  href="/about/organization"
-                  color="secondary"
-                  variant="contained"
-                  size="large"
-                  endIcon={<ArrowForward />}
-                >
-                  <Typography variant="inherit" noWrap>
-                    Alle organisasjoner
-                  </Typography>
-                </Button>
-              </SwiperSlide>
-            </Swiper>
-          </NoSsr>
+        <Stack direction="row" minWidth="max-content" alignItems="center">
+          <Box ref={orgsTitleEl}>
+            <Typography
+              variant="h4"
+              sx={{
+                opacity: sliderActiveIndex == 0 ? 1 : 0,
+                transition: (theme) => theme.transitions.create("opacity"),
+              }}
+            >
+              Våre <br />
+              Foreninger
+            </Typography>
+          </Box>
+          <Organizations onActiveIndexChange={onActiveIndexChange} offsetX={sliderOffsetX + 48} />
         </Stack>
       </Container>
-    </Container>
+    </Box>
   );
 };
+
+export default OrganizationsSlider;

--- a/frontend/src/app/_components/LandingHero/OrganizationsSlider.tsx
+++ b/frontend/src/app/_components/LandingHero/OrganizationsSlider.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Box, Container, Stack, Typography } from "@mui/material";
+import { Box, Container, Fade, Stack, Typography } from "@mui/material";
 import { useEffect, useRef, useState } from "react";
+
 import Organizations from "./Organizations";
 
 const OrganizationsSlider: React.FC = () => {
@@ -9,6 +10,7 @@ const OrganizationsSlider: React.FC = () => {
 
   const [sliderActiveIndex, setSliderActiveIndex] = useState(0);
   const [sliderOffsetX, setSliderOffsetX] = useState(0);
+  const [refInView, setRefInView] = useState(false);
 
   const onActiveIndexChange = (index: number) => {
     setSliderActiveIndex(index);
@@ -17,6 +19,7 @@ const OrganizationsSlider: React.FC = () => {
   const updateSliderOffset = () => {
     if (orgsTitleEl.current) {
       setSliderOffsetX(orgsTitleEl.current.offsetWidth + orgsTitleEl.current.offsetLeft);
+      setRefInView(true);
     }
   };
 
@@ -44,21 +47,23 @@ const OrganizationsSlider: React.FC = () => {
       }}
     >
       <Container>
-        <Stack direction="row" minWidth="max-content" alignItems="center">
-          <Box ref={orgsTitleEl}>
-            <Typography
-              variant="h4"
-              sx={{
-                opacity: sliderActiveIndex == 0 ? 1 : 0,
-                transition: (theme) => theme.transitions.create("opacity"),
-              }}
-            >
-              Våre <br />
-              Foreninger
-            </Typography>
-          </Box>
-          <Organizations onActiveIndexChange={onActiveIndexChange} offsetX={sliderOffsetX + 48} />
-        </Stack>
+        <Fade in={refInView}>
+          <Stack direction="row" minWidth="max-content" alignItems="center">
+            <Box ref={orgsTitleEl}>
+              <Typography
+                variant="h4"
+                sx={{
+                  opacity: sliderActiveIndex == 0 ? 1 : 0,
+                  transition: (theme) => theme.transitions.create("opacity"),
+                }}
+              >
+                Våre <br />
+                Foreninger
+              </Typography>
+            </Box>
+            <Organizations onActiveIndexChange={onActiveIndexChange} offsetX={sliderOffsetX + 48} />
+          </Stack>
+        </Fade>
       </Container>
     </Box>
   );

--- a/frontend/src/app/_components/LandingHero/index.tsx
+++ b/frontend/src/app/_components/LandingHero/index.tsx
@@ -28,7 +28,7 @@ export const LandingHero: React.FC = () => {
             gridTemplateColumns: "repeat(12, 1fr)",
           }}
         >
-          <Box gridColumn={{ md: "1 / 8", xs: "1 / -1" }} display="flex" justifyContent="center">
+          <Box gridColumn={{ md: "auto", xs: "1 / -1" }} display="flex" justifyContent="center">
             <Grid
               container
               direction="column"
@@ -49,7 +49,7 @@ export const LandingHero: React.FC = () => {
                 </Typography>
               </Grid>
               <Grid>
-                <Typography variant="h1" textAlign={{ xs: "center", md: "left" }}>
+                <Typography variant="h1" textAlign={{ xs: "center", md: "left" }} letterSpacing={"-0.02em"}>
                   Industriell Økonomi & Teknologiledelse
                 </Typography>
               </Grid>

--- a/frontend/src/app/_components/LandingHero/index.tsx
+++ b/frontend/src/app/_components/LandingHero/index.tsx
@@ -6,7 +6,7 @@ import Image from "next/image";
 import { Link } from "@/app/components/Link";
 import Hero from "~/public/static/landing/hero.webp";
 
-import { OrganizationsSlider } from "./OrganizationsSlider";
+import OrganizationsSlider from "./OrganizationsSlider";
 
 export const LandingHero: React.FC = () => {
   return (

--- a/frontend/src/components/pages/events/AllEvents.tsx
+++ b/frontend/src/components/pages/events/AllEvents.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@apollo/client";
 import { ResultOf } from "@graphql-typed-document-node/core";
 import { Tune } from "@mui/icons-material";
-import { Button, Drawer, Unstable_Grid2 as Grid, Skeleton, Stack, Typography } from "@mui/material";
+import { Box, Button, Drawer, Unstable_Grid2 as Grid, Skeleton, Stack, Typography } from "@mui/material";
 import React, { useState } from "react";
 
 import { PermissionRequired } from "@/components";
@@ -104,7 +104,7 @@ export const AllEvents: React.FC = () => {
   });
 
   return (
-    <Grid container direction="row" spacing={2}>
+    <Grid container direction="row" spacing={4}>
       <PermissionRequired permission="events.add_event">
         <Grid xs={12}>
           <ManageEvents />
@@ -112,7 +112,7 @@ export const AllEvents: React.FC = () => {
       </PermissionRequired>
       <Grid xs display={{ xs: "block", md: "none" }}>
         <Button
-          variant="outlined"
+          variant="contained"
           color="secondary"
           fullWidth
           startIcon={<Tune />}
@@ -121,22 +121,17 @@ export const AllEvents: React.FC = () => {
           Filter
         </Button>
         <Drawer anchor="left" open={openFilterDrawer} onClose={() => setOpenFilterDrawer(false)}>
-          <FilterMenu
-            filters={filters}
-            onFiltersChange={handleFilterChange}
-            showDefaultEvents={showDefaultEvents}
-            onShowDefaultChange={setShowDefaultEvents}
-          />
+          <Box py={2} px={3}>
+            <FilterMenu
+              filters={filters}
+              onFiltersChange={handleFilterChange}
+              showDefaultEvents={showDefaultEvents}
+              onShowDefaultChange={setShowDefaultEvents}
+            />
+          </Box>
         </Drawer>
       </Grid>
-      <Grid display={{ xs: "none", md: "block" }} md={3}>
-        <FilterMenu
-          filters={filters}
-          onFiltersChange={handleFilterChange}
-          showDefaultEvents={showDefaultEvents}
-          onShowDefaultChange={setShowDefaultEvents}
-        />
-      </Grid>
+
       <Grid xs={12} md={9}>
         <Stack direction="column" spacing={4}>
           {loading && <EventSkeleton />}
@@ -176,6 +171,14 @@ export const AllEvents: React.FC = () => {
             </Stack>
           )}
         </Stack>
+      </Grid>
+      <Grid display={{ xs: "none", md: "block" }} md={3}>
+        <FilterMenu
+          filters={filters}
+          onFiltersChange={handleFilterChange}
+          showDefaultEvents={showDefaultEvents}
+          onShowDefaultChange={setShowDefaultEvents}
+        />
       </Grid>
     </Grid>
   );

--- a/frontend/src/components/pages/events/EventListItem.tsx
+++ b/frontend/src/components/pages/events/EventListItem.tsx
@@ -60,7 +60,7 @@ type StatusChipProps = {
 };
 
 function StatusChip({ event, user }: StatusChipProps): React.ReactElement | null {
-  if (user.isSignedUp) return <Chip label="Påmeldt" variant="outlined" color="primary" />;
+  if (user.isSignedUp) return <Chip label="Påmeldt" variant="filled" color="success" />;
   if (user.isOnWaitingList) return <Chip label="På venteliste" />;
 
   const signUpOpenDate = event.signupOpenDate ? dayjs(event.signupOpenDate) : undefined;

--- a/frontend/src/components/pages/events/FilterMenu/index.tsx
+++ b/frontend/src/components/pages/events/FilterMenu/index.tsx
@@ -1,5 +1,5 @@
 import { Refresh, StarOutlineRounded, StarRounded } from "@mui/icons-material";
-import { Card, CardContent, Divider, Grid, IconButton, Tooltip, Typography } from "@mui/material";
+import { Box, Divider, Grid, IconButton, Tooltip, Typography } from "@mui/material";
 import React from "react";
 
 import { FilterQuery } from "../AllEvents";
@@ -30,56 +30,54 @@ export const FilterMenu: React.FC<Props> = ({ filters, onFiltersChange, showDefa
     }
   };
   return (
-    <Card>
-      <CardContent>
-        <Grid container direction="column" spacing={3}>
-          <Grid container item direction="row" justifyContent="space-between" alignItems="center">
-            <Grid item>
-              <Typography variant="subtitle1">Filter</Typography>
-            </Grid>
-            <Grid item>
-              <Tooltip title="Nullstill filter" arrow>
-                <IconButton onClick={() => onFiltersChange({})} aria-label="delete">
-                  <Refresh />
-                </IconButton>
-              </Tooltip>
-            </Grid>
+    <Box>
+      <Grid container direction="column" spacing={2}>
+        <Grid container item direction="row" justifyContent="space-between" alignItems="center">
+          <Grid item>
+            <Typography variant="subtitle1">Filter</Typography>
           </Grid>
           <Grid item>
-            <Divider />
-          </Grid>
-          <Grid container item direction="row" justifyContent="space-between" alignItems="center">
-            <Grid item>
-              <Typography variant="body1">Fremhevet</Typography>
-            </Grid>
-            <Grid item>
-              <IconButton onClick={() => onShowDefaultChange(!showDefaultEvents)} aria-label="delete">
-                {showDefaultEvents ? <StarRounded color="warning" /> : <StarOutlineRounded />}
+            <Tooltip title="Nullstill filter" arrow>
+              <IconButton onClick={() => onFiltersChange({})} aria-label="delete">
+                <Refresh />
               </IconButton>
-            </Grid>
+            </Tooltip>
           </Grid>
-          <Grid item>
-            <Divider />
-          </Grid>
-          <Grid item>
-            <Typography variant="subtitle2">Arrangør</Typography>
-          </Grid>
-          <OrganizationFilter filters={filters} handleChecked={handleChecked} />
-
-          <Grid item>
-            <Divider />
-          </Grid>
-          <Grid item>
-            <Typography variant="subtitle2">Kategori</Typography>
-          </Grid>
-          <CategoryFilter filters={filters} handleChecked={handleChecked} />
-
-          <Grid item>
-            <Divider />
-          </Grid>
-          <DateTimeFilter filters={filters} onFiltersChange={onFiltersChange} />
         </Grid>
-      </CardContent>
-    </Card>
+        <Grid item>
+          <Divider />
+        </Grid>
+        <Grid container item direction="row" justifyContent="space-between" alignItems="center">
+          <Grid item>
+            <Typography variant="body1">Fremhevet</Typography>
+          </Grid>
+          <Grid item>
+            <IconButton onClick={() => onShowDefaultChange(!showDefaultEvents)} aria-label="delete">
+              {showDefaultEvents ? <StarRounded color="warning" /> : <StarOutlineRounded />}
+            </IconButton>
+          </Grid>
+        </Grid>
+        <Grid item>
+          <Divider />
+        </Grid>
+        <Grid item>
+          <Typography variant="subtitle2">Arrangør</Typography>
+        </Grid>
+        <OrganizationFilter filters={filters} handleChecked={handleChecked} />
+
+        <Grid item>
+          <Divider />
+        </Grid>
+        <Grid item>
+          <Typography variant="subtitle2">Kategori</Typography>
+        </Grid>
+        <CategoryFilter filters={filters} handleChecked={handleChecked} />
+
+        <Grid item>
+          <Divider />
+        </Grid>
+        <DateTimeFilter filters={filters} onFiltersChange={onFiltersChange} />
+      </Grid>
+    </Box>
   );
 };

--- a/frontend/src/lib/mui/theme/shadows/index.ts
+++ b/frontend/src/lib/mui/theme/shadows/index.ts
@@ -1,29 +1,34 @@
 import { CssVarsThemeOptions } from "@mui/material/styles";
 
+const shadowBorder = "0 0 0 1px rgba(0,0,0,0.06)";
+
+const createProgressiveShadow = (y: number, blur: number, spread = 0, opacity = 0.04) =>
+  `0px ${y}px ${blur}px ${spread}px rgba(0, 0, 0, ${opacity})`;
+
 export const shadows: CssVarsThemeOptions["shadows"] = [
   "none",
-  `0px 2px 1px -1px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 1px 1px 0px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 1px 3px 0px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 3px 1px -2px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 2px 2px 0px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 1px 5px 0px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 3px 3px -2px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 3px 4px 0px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 1px 8px 0px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 2px 4px -1px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 4px 5px 0px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 1px 10px 0px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 3px 5px -1px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 5px 8px 0px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 1px 14px 0px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 3px 5px -1px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 6px 10px 0px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 1px 18px 0px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 4px 5px -2px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 7px 10px 1px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 2px 16px 1px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 5px 5px -3px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 8px 10px 1px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 3px 14px 2px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 5px 6px -3px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 9px 12px 1px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 3px 16px 2px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 6px 6px -3px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 10px 14px 1px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 4px 18px 3px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 6px 7px -4px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 11px 15px 1px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 4px 20px 3px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 7px 8px -4px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 12px 17px 2px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 5px 22px 4px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 7px 8px -4px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 13px 19px 2px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 5px 24px 4px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 7px 9px -4px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 14px 21px 2px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 5px 26px 4px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 8px 9px -5px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 15px 22px 2px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 6px 28px 5px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 8px 10px -5px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 16px 24px 2px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 6px 30px 5px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 8px 11px -5px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 17px 26px 2px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 6px 32px 5px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 9px 11px -5px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 18px 28px 2px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 7px 34px 6px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 9px 12px -6px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 19px 29px 2px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 7px 36px 6px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 10px 13px -6px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 20px 31px 3px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 8px 38px 7px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 10px 13px -6px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 21px 33px 3px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 8px 40px 7px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 10px 14px -6px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 22px 35px 3px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 8px 42px 7px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 11px 14px -7px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 23px 36px 3px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 9px 44px 8px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
-  `0px 11px 15px -7px rgba(var(--mui-palette-shadowChannel) / 0.10),0px 24px 38px 3px rgba(var(--mui-palette-shadowChannel) / 0.08),0px 9px 46px 8px rgba(var(--mui-palette-shadowChannel) / 0.04)`,
+  `${shadowBorder}, ${createProgressiveShadow(1, 2)}`, // 1
+  `${shadowBorder}, ${createProgressiveShadow(2, 4)}`, // 2
+  `${shadowBorder}, ${createProgressiveShadow(2, 4)}, ${createProgressiveShadow(4, 6, -2)}`, // 3
+  `${shadowBorder}, ${createProgressiveShadow(2, 4)}, ${createProgressiveShadow(6, 8, -3)}`, // 4
+  `${shadowBorder}, ${createProgressiveShadow(3, 5)}, ${createProgressiveShadow(8, 10, -4)}`, // 5
+  `${shadowBorder}, ${createProgressiveShadow(3, 6)}, ${createProgressiveShadow(10, 12, -4)}`, // 6
+  `${shadowBorder}, ${createProgressiveShadow(4, 7)}, ${createProgressiveShadow(12, 14, -4)}`, // 7
+  `${shadowBorder}, ${createProgressiveShadow(5, 8)}, ${createProgressiveShadow(14, 16, -4)}`, // 8
+  `${shadowBorder}, ${createProgressiveShadow(5, 9)}, ${createProgressiveShadow(16, 18, -4)}`, // 9
+  `${shadowBorder}, ${createProgressiveShadow(6, 10)}, ${createProgressiveShadow(18, 20, -4)}`, // 10
+  `${shadowBorder}, ${createProgressiveShadow(6, 11)}, ${createProgressiveShadow(20, 22, -4)}`, // 11
+  `${shadowBorder}, ${createProgressiveShadow(7, 12)}, ${createProgressiveShadow(22, 24, -4)}`, // 12
+  `${shadowBorder}, ${createProgressiveShadow(7, 13)}, ${createProgressiveShadow(24, 26, -4)}`, // 13
+  `${shadowBorder}, ${createProgressiveShadow(7, 14)}, ${createProgressiveShadow(26, 28, -4)}`, // 14
+  `${shadowBorder}, ${createProgressiveShadow(8, 15)}, ${createProgressiveShadow(28, 30, -4)}`, // 15
+  `${shadowBorder}, ${createProgressiveShadow(8, 16)}, ${createProgressiveShadow(30, 32, -4)}`, // 16
+  `${shadowBorder}, ${createProgressiveShadow(8, 17)}, ${createProgressiveShadow(32, 34, -4)}`, // 17
+  `${shadowBorder}, ${createProgressiveShadow(9, 18)}, ${createProgressiveShadow(34, 36, -4)}`, // 18
+  `${shadowBorder}, ${createProgressiveShadow(9, 19)}, ${createProgressiveShadow(36, 38, -4)}`, // 19
+  `${shadowBorder}, ${createProgressiveShadow(10, 20)}, ${createProgressiveShadow(38, 40, -4)}`, // 20
+  `${shadowBorder}, ${createProgressiveShadow(10, 21)}, ${createProgressiveShadow(40, 42, -4)}`, // 21
+  `${shadowBorder}, ${createProgressiveShadow(10, 22)}, ${createProgressiveShadow(42, 44, -4)}`, // 22
+  `${shadowBorder}, ${createProgressiveShadow(11, 23)}, ${createProgressiveShadow(44, 46, -4)}`, // 23
+  `${shadowBorder}, ${createProgressiveShadow(11, 24)}, ${createProgressiveShadow(46, 48, -4)}`, // 24
 ];


### PR DESCRIPTION
### Changes
- New shadows inspired by Vercel's Geist design system
- Refactored the front-page slider, preventing the ugly cutoff

<img width="1474" alt="image" src="https://github.com/user-attachments/assets/f886f55e-6007-46ef-9ccd-93931daa4129" />
<img width="1475" alt="Screenshot 2025-02-22 at 19 08 26" src="https://github.com/user-attachments/assets/7bdefd00-9f35-4257-8cab-2f26087101ee" />

- Moved the filter menu over to the right side of the events page and removed the box around it
<img width="1128" alt="image" src="https://github.com/user-attachments/assets/ab5754f5-aee6-4778-9905-8ada2714deec" />

