### PR TITLE
fix: dont let image overflow parent

### DIFF
--- a/frontend/src/components/pages/listings/index/ListingItem.tsx
+++ b/frontend/src/components/pages/listings/index/ListingItem.tsx
@@ -77,6 +77,7 @@ export const ListingItem: React.FC<Props> = ({ listing }) => {
             <img
               src={listing.organization?.logoUrl || "/nth.svg"}
               alt=""
+              style={{ height: "100%", width: "100%" }}
               onError={(e) => (
                 ((e.target as HTMLImageElement).onerror = null), ((e.target as HTMLImageElement).src = "/nth.svg")
               )}


### PR DESCRIPTION
### Changes

- set image size to stop image from overflowing its container size

Before:
<img width="448" height="432" alt="image" src="https://github.com/user-attachments/assets/a2815041-ee3b-47eb-9326-356335972679" />

After:
<img width="438" height="426" alt="image" src="https://github.com/user-attachments/assets/4efffe47-0eab-438e-a615-8a52cc894d8b" />
