### PR TITLE
Change rubberok leaders 2025

### DIFF
--- a/frontend/content/organizations/rubberdok.md
+++ b/frontend/content/organizations/rubberdok.md
@@ -6,11 +6,11 @@ image: /img/rubberdoklogo1.png
 alt: Logoen til rubberdøk
 board:
   ceo:
-    name: Hannah Köberle
+    name: Oda Fu Zhe Runde
     title: Prosjektleder
     mail: leder@rubberdok.no
   cto:
-    name: Oda Fu Zhe Runde
+    name: Tien Quoc Tran
     title: Prosjektleder
     mail: leder@rubberdok.no
 tag: annet


### PR DESCRIPTION
### Changes
- Changed info about leaders of Rubberdøk

Before:
<img width="1900" height="788" alt="image" src="https://github.com/user-attachments/assets/ce66624d-03ac-4814-8b48-02e562a26ce0" />

After:
<img width="1896" height="797" alt="Skjermbilde 2025-08-19 175645" src="https://github.com/user-attachments/assets/e982a8e9-206a-4a96-8c7d-64621e446b8a" />



