### PR TITLE
Fikset listeelement generering

### DIFF
--- a/frontend/src/components/Markdown/components.tsx
+++ b/frontend/src/components/Markdown/components.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, Divider, List, ListItemText, ListItem as MuiListItem, Typography } from "@mui/material";
+import { Card, CardContent, Divider, List, ListItem as MuiListItem, Typography } from "@mui/material";
 import { listItemClasses } from "@mui/material/ListItem";
 import { styled } from "@mui/material/styles";
 import { typographyClasses } from "@mui/material/Typography";
@@ -92,8 +92,14 @@ const OrderedList: Components["ol"] = ({ children }) => {
 
 const ListItem: Components["li"] = ({ children }) => {
   return (
-    <MuiListItem>
-      <ListItemText primary={children} />
+    <MuiListItem
+      sx={{
+        display: "list-item",
+        py: 0,
+        px: 0,
+      }}
+    >
+      {children}
     </MuiListItem>
   );
 };


### PR DESCRIPTION
 tld;dr: Lister blir generert som <ul><li> ikke <ul><div><li>. 
 Slik man får linje basert liste elementer, slik det skal være.

Endret hvordan siden blir generert fra markdown, slik at ListItems blir generert rett under MuiListItem istedenfor under ett element som lager en div til.

Har ikke funnet noen plass hvor dette har ødelagt noe annet.

### Changes

> Kun i ./frontend/src/components/Markdown/components.tsx

- Fjernet `<ListItemText>` under `<ListItem>` da denne lager en egen `<div>`i HTML-en, som gjorde at listen ikke var på en linje.
- Fjernet referansen til dette i imports, da det ikke lenger er i bruk.
