### PR TITLE
Fjernet deprecated, og oppdatert med nye varianter.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         linter: [black, flake8]
@@ -43,7 +43,7 @@ jobs:
 
   build:
     name: Build backend
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       dockerfile: backend-production
@@ -70,7 +70,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: indokweb-backend
           IMAGE_TAG: ${{ github.sha }}
-        run: echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+        run: echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         id: buildx
@@ -113,7 +113,7 @@ jobs:
 
   api:
     name: API tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: build
 
     services:
@@ -170,7 +170,7 @@ jobs:
           fail_ci_if_error: true
 
   prepare:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       uuid: ${{ steps.uuid.outputs.value }}
     steps:
@@ -179,11 +179,11 @@ jobs:
         # take the current commit + timestamp together
         # the typical value would be something like
         # "sha-5d3fe...35d3-time-1620841214"
-        run: echo "::set-output name=value::sha-$GITHUB_SHA-time-$(date +"%s")"
+        run: echo "value=sha-$GITHUB_SHA-time-$(date +'%s')" >> "$GITHUB_OUTPUT"
 
   build-frontend:
     name: Build frontend
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     env:
       dockerfile: frontend-test
@@ -232,7 +232,7 @@ jobs:
   e2e:
     needs: [prepare, build, build-frontend]
     name: E2E Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -280,7 +280,7 @@ jobs:
 
   deploy:
     name: Deploy to ECS
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     needs: [api, e2e]
     if: github.ref == 'refs/heads/main'
@@ -319,7 +319,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: indokweb-backend
           IMAGE_TAG: ${{ github.sha }}
-        run: echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+        run: echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Update task definition
         id: task-def


### PR DESCRIPTION
Endret fra ubuntu-20.04 til ubuntu-latest, da det ikke lenger er støttet med 20.04. Også endret echo commands fra "::set-output" til "$GITHUB_OUTPUT", og medfølgende formatering, da denne er deprecated.
